### PR TITLE
feat: Backfill classification: 281 new casks, 13 renames migrated, 28 pruned

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-04-13",
-  "totalCasks": 3534,
+  "generatedDate": "2026-07-06",
+  "totalCasks": 3786,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -148,6 +148,12 @@
     "86box": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "8bitdo-firmware-updater": {
+      "primary": "utilities",
+      "secondary": [
+        "games"
+      ]
     },
     "8bitdo-ultimate-software": {
       "primary": "utilities",
@@ -303,6 +309,13 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "adrafinil": {
+      "primary": "utilities",
+      "secondary": [
+        "ai",
+        "developerTools"
+      ]
+    },
     "adrive": {
       "primary": "cloudStorage",
       "secondary": []
@@ -337,10 +350,6 @@
       "primary": "designGraphics",
       "secondary": []
     },
-    "after-dark-classic": {
-      "primary": "screensaverWallpaper",
-      "secondary": []
-    },
     "agent-tars": {
       "primary": "developerTools",
       "secondary": [
@@ -348,6 +357,19 @@
       ]
     },
     "agentkube": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "agentsmesh": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "developerTools"
+      ]
+    },
+    "agentsview": {
       "primary": "developerTools",
       "secondary": [
         "ai"
@@ -408,6 +430,12 @@
     "airfoil": {
       "primary": "audioMusic",
       "secondary": []
+    },
+    "airi": {
+      "primary": "games",
+      "secondary": [
+        "ai"
+      ]
     },
     "airmedia": {
       "primary": "communication",
@@ -537,9 +565,22 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "altar-ai": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "communication"
+      ]
+    },
     "alternote": {
       "primary": "productivity",
       "secondary": []
+    },
+    "altersend": {
+      "primary": "utilities",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "altserver": {
       "primary": "utilities",
@@ -594,6 +635,12 @@
     "amneziavpn": {
       "primary": "securityPrivacy",
       "secondary": []
+    },
+    "amore": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "ampps": {
       "primary": "developerTools",
@@ -651,6 +698,12 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "annotate": {
+      "primary": "designGraphics",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "another-redis-desktop-manager": {
       "primary": "developerTools",
       "secondary": []
@@ -660,6 +713,18 @@
       "secondary": []
     },
     "antigravity": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "antigravity-cli": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "antigravity-ide": {
       "primary": "developerTools",
       "secondary": [
         "ai"
@@ -771,6 +836,12 @@
       "primary": "securityPrivacy",
       "secondary": []
     },
+    "appgridmac": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "apple-hewlett-packard-printer-drivers": {
       "primary": "utilities",
       "secondary": []
@@ -855,6 +926,10 @@
       "primary": "games",
       "secondary": []
     },
+    "ariax": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "arm-performance-libraries": {
       "primary": "scienceEducation",
       "secondary": []
@@ -886,6 +961,12 @@
     "asciidocfx": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "aside": {
+      "primary": "browsers",
+      "secondary": [
+        "ai"
+      ]
     },
     "asset-catalog-tinkerer": {
       "primary": "developerTools",
@@ -930,6 +1011,18 @@
     "atok": {
       "primary": "utilities",
       "secondary": []
+    },
+    "atoll": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
+    },
+    "atomcode": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "atomic-wallet": {
       "primary": "financeCrypto",
@@ -997,6 +1090,12 @@
         "ai"
       ]
     },
+    "auto-subs": {
+      "primary": "videoMedia",
+      "secondary": [
+        "ai"
+      ]
+    },
     "autodesk-fusion": {
       "primary": "designGraphics",
       "secondary": []
@@ -1004,6 +1103,12 @@
     "autodmg": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "autofirma": {
+      "primary": "productivity",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "autogram": {
       "primary": "productivity",
@@ -1101,6 +1206,12 @@
       "primary": "cloudStorage",
       "secondary": []
     },
+    "backblaze-restore": {
+      "primary": "cloudStorage",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "backdrop": {
       "primary": "screensaverWallpaper",
       "secondary": []
@@ -1184,6 +1295,12 @@
       "primary": "financeCrypto",
       "secondary": []
     },
+    "baoliandeng": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "bartender": {
       "primary": "menuBar",
       "secondary": []
@@ -1195,6 +1312,12 @@
     "basecamp": {
       "primary": "productivity",
       "secondary": []
+    },
+    "baseline": {
+      "primary": "utilities",
+      "secondary": [
+        "developerTools"
+      ]
     },
     "basictex": {
       "primary": "scienceEducation",
@@ -1313,6 +1436,18 @@
     "betterandbetter": {
       "primary": "utilities",
       "secondary": []
+    },
+    "bettercapture": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
+    },
+    "bettercmdtab": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
     },
     "betterdisplay": {
       "primary": "utilities",
@@ -1552,10 +1687,6 @@
       "primary": "audioMusic",
       "secondary": []
     },
-    "blurred": {
-      "primary": "utilities",
-      "secondary": []
-    },
     "blurscreen": {
       "primary": "utilities",
       "secondary": []
@@ -1628,10 +1759,6 @@
         "ai"
       ]
     },
-    "bot-framework-emulator": {
-      "primary": "developerTools",
-      "secondary": []
-    },
     "box-drive": {
       "primary": "cloudStorage",
       "secondary": []
@@ -1651,6 +1778,12 @@
     "brave-browser": {
       "primary": "browsers",
       "secondary": []
+    },
+    "brave-origin": {
+      "primary": "browsers",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "breaktimer": {
       "primary": "productivity",
@@ -1754,10 +1887,6 @@
       "primary": "securityPrivacy",
       "secondary": []
     },
-    "burp-suite-professional": {
-      "primary": "securityPrivacy",
-      "secondary": []
-    },
     "busycal": {
       "primary": "productivity",
       "secondary": []
@@ -1777,6 +1906,13 @@
     "butterkit": {
       "primary": "utilities",
       "secondary": []
+    },
+    "buzz": {
+      "primary": "audioMusic",
+      "secondary": [
+        "ai",
+        "productivity"
+      ]
     },
     "bwana": {
       "primary": "utilities",
@@ -1798,16 +1934,18 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "cadran": {
+      "primary": "screensaverWallpaper",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "cadreader": {
       "primary": "designGraphics",
       "secondary": []
     },
     "caffeine": {
       "primary": "utilities",
-      "secondary": []
-    },
-    "cahier": {
-      "primary": "scienceEducation",
       "secondary": []
     },
     "caido": {
@@ -1826,9 +1964,19 @@
       "primary": "utilities",
       "secondary": []
     },
+    "caldigit-usb-hub-support-driver": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "calendar-366": {
       "primary": "menuBar",
       "secondary": []
+    },
+    "calendr": {
+      "primary": "menuBar",
+      "secondary": [
+        "productivity"
+      ]
     },
     "calhash": {
       "primary": "utilities",
@@ -1960,9 +2108,27 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "cavalry": {
+      "primary": "designGraphics",
+      "secondary": [
+        "videoMedia"
+      ]
+    },
     "cave-story": {
       "primary": "games",
       "secondary": []
+    },
+    "cc-pocket": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "cc-switch": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "ccleaner": {
       "primary": "utilities",
@@ -1978,10 +2144,6 @@
     },
     "celestia": {
       "primary": "scienceEducation",
-      "secondary": []
-    },
-    "celestialteapot-runway": {
-      "primary": "designGraphics",
       "secondary": []
     },
     "cemu": {
@@ -2082,6 +2244,10 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "chiri": {
+      "primary": "productivity",
+      "secondary": []
+    },
     "chitubox": {
       "primary": "designGraphics",
       "secondary": []
@@ -2094,6 +2260,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "choragus": {
+      "primary": "audioMusic",
+      "secondary": [
+        "menuBar"
+      ]
+    },
     "chordpotion": {
       "primary": "audioMusic",
       "secondary": []
@@ -2105,6 +2277,12 @@
     "chronoagent": {
       "primary": "cloudStorage",
       "secondary": []
+    },
+    "chronoid": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
     },
     "chronosync": {
       "primary": "cloudStorage",
@@ -2138,10 +2316,6 @@
       "primary": "communication",
       "secondary": []
     },
-    "cisco-proximity": {
-      "primary": "communication",
-      "secondary": []
-    },
     "cisdem-data-recovery": {
       "primary": "utilities",
       "secondary": []
@@ -2169,6 +2343,12 @@
     "clamxav": {
       "primary": "securityPrivacy",
       "secondary": []
+    },
+    "clarify": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "clariti": {
       "primary": "audioMusic",
@@ -2206,16 +2386,16 @@
         "ai"
       ]
     },
-    "claudebar": {
-      "primary": "menuBar",
+    "claude-devtools": {
+      "primary": "developerTools",
       "secondary": [
         "ai"
       ]
     },
-    "clay": {
-      "primary": "productivity",
+    "claudebar": {
+      "primary": "menuBar",
       "secondary": [
-        "communication"
+        "ai"
       ]
     },
     "cleanapp": {
@@ -2246,6 +2426,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "clearance": {
+      "primary": "productivity",
+      "secondary": [
+        "developerTools"
+      ]
+    },
     "clearvpn": {
       "primary": "securityPrivacy",
       "secondary": []
@@ -2265,6 +2451,12 @@
     "clicker-for-youtube": {
       "primary": "videoMedia",
       "secondary": []
+    },
+    "clickshare": {
+      "primary": "utilities",
+      "secondary": [
+        "communication"
+      ]
     },
     "clickup": {
       "primary": "productivity",
@@ -2376,6 +2568,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "cmux": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "cockatrice": {
       "primary": "games",
       "secondary": []
@@ -2426,6 +2624,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "codeexpander": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "codekit": {
       "primary": "developerTools",
       "secondary": []
@@ -2441,10 +2645,6 @@
       ]
     },
     "coderunner": {
-      "primary": "developerTools",
-      "secondary": []
-    },
-    "codeship-jet": {
       "primary": "developerTools",
       "secondary": []
     },
@@ -2542,7 +2742,7 @@
         "ai"
       ]
     },
-    "comfyui": {
+    "comfy": {
       "primary": "designGraphics",
       "secondary": [
         "ai"
@@ -2620,6 +2820,10 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "connectiq-sdk-manager": {
+      "primary": "developerTools",
+      "secondary": []
+    },
     "connectmenow": {
       "primary": "utilities",
       "secondary": []
@@ -2664,6 +2868,12 @@
         "ai"
       ]
     },
+    "copilot-language-server": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "copilot-money": {
       "primary": "financeCrypto",
       "secondary": []
@@ -2680,6 +2890,12 @@
       "primary": "utilities",
       "secondary": [
         "securityPrivacy"
+      ]
+    },
+    "corelocationcli": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
       ]
     },
     "cork": {
@@ -2706,6 +2922,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "cotypist": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
     "couchbase-server-community": {
       "primary": "developerTools",
       "secondary": []
@@ -2722,7 +2944,19 @@
       "primary": "utilities",
       "secondary": []
     },
+    "cpuinfo": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "craft": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "craft-agents": {
       "primary": "productivity",
       "secondary": [
         "ai"
@@ -2787,6 +3021,12 @@
     "crystalviewer": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "ctivo": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
     },
     "cubicsdr": {
       "primary": "scienceEducation",
@@ -2908,6 +3148,12 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "datadog-agent": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "datadog-security-cli": {
       "primary": "securityPrivacy",
       "secondary": [
@@ -2929,12 +3175,6 @@
     "datasette-desktop": {
       "primary": "developerTools",
       "secondary": []
-    },
-    "dataspell": {
-      "primary": "developerTools",
-      "secondary": [
-        "ai"
-      ]
     },
     "datovka": {
       "primary": "communication",
@@ -2964,6 +3204,10 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "dbeaverteam": {
+      "primary": "developerTools",
+      "secondary": []
+    },
     "dbeaverultimate": {
       "primary": "developerTools",
       "secondary": []
@@ -2984,8 +3228,60 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "dbvr": {
+      "primary": "developerTools",
+      "secondary": []
+    },
+    "dbx": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "dcommander": {
       "primary": "utilities",
+      "secondary": []
+    },
+    "dcp-o-matic": {
+      "primary": "videoMedia",
+      "secondary": []
+    },
+    "dcp-o-matic-batch-converter": {
+      "primary": "videoMedia",
+      "secondary": []
+    },
+    "dcp-o-matic-combiner": {
+      "primary": "videoMedia",
+      "secondary": []
+    },
+    "dcp-o-matic-disk-writer": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
+    },
+    "dcp-o-matic-editor": {
+      "primary": "videoMedia",
+      "secondary": []
+    },
+    "dcp-o-matic-encode-server": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
+    },
+    "dcp-o-matic-kdm-creator": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
+    },
+    "dcp-o-matic-player": {
+      "primary": "videoMedia",
+      "secondary": []
+    },
+    "dcp-o-matic-playlist-editor": {
+      "primary": "videoMedia",
       "secondary": []
     },
     "dcv-viewer": {
@@ -3003,6 +3299,12 @@
     "ddpm": {
       "primary": "utilities",
       "secondary": []
+    },
+    "deadbolt": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
     },
     "decentr": {
       "primary": "browsers",
@@ -3114,6 +3416,18 @@
       "primary": "games",
       "secondary": []
     },
+    "devin-cli": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "devin-desktop": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "devkinsta": {
       "primary": "developerTools",
       "secondary": []
@@ -3158,6 +3472,10 @@
     },
     "dexed": {
       "primary": "audioMusic",
+      "secondary": []
+    },
+    "dfu-blaster-pro": {
+      "primary": "utilities",
       "secondary": []
     },
     "dhs": {
@@ -3294,6 +3612,12 @@
       "primary": "securityPrivacy",
       "secondary": []
     },
+    "do-not-disturb": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "dockdoor": {
       "primary": "utilities",
       "secondary": []
@@ -3321,6 +3645,12 @@
     "dockside": {
       "primary": "utilities",
       "secondary": []
+    },
+    "dockspace": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
     },
     "dockview": {
       "primary": "utilities",
@@ -3366,6 +3696,18 @@
       "primary": "games",
       "secondary": []
     },
+    "dot": {
+      "primary": "menuBar",
+      "secondary": [
+        "productivity"
+      ]
+    },
+    "dotnet-reactor": {
+      "primary": "developerTools",
+      "secondary": [
+        "securityPrivacy"
+      ]
+    },
     "dotnet-runtime": {
       "primary": "developerTools",
       "secondary": []
@@ -3396,6 +3738,10 @@
     },
     "doxie": {
       "primary": "utilities",
+      "secondary": []
+    },
+    "doxygen-app": {
+      "primary": "developerTools",
       "secondary": []
     },
     "drata-agent": {
@@ -3490,6 +3836,12 @@
       "primary": "securityPrivacy",
       "secondary": []
     },
+    "duo-desktop": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "duplicacy-cli": {
       "primary": "cloudStorage",
       "secondary": []
@@ -3514,9 +3866,19 @@
       "primary": "securityPrivacy",
       "secondary": []
     },
+    "dusklight": {
+      "primary": "games",
+      "secondary": []
+    },
     "dwarf-fortress-lmp": {
       "primary": "games",
       "secondary": []
+    },
+    "dwellclick": {
+      "primary": "utilities",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "dyad": {
       "primary": "developerTools",
@@ -3558,6 +3920,10 @@
     },
     "ears": {
       "primary": "audioMusic",
+      "secondary": []
+    },
+    "easy-move+resize": {
+      "primary": "utilities",
       "secondary": []
     },
     "easydevo": {
@@ -3633,6 +3999,12 @@
     "edrawmind": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "eez-studio": {
+      "primary": "developerTools",
+      "secondary": [
+        "designGraphics"
+      ]
     },
     "effect-house": {
       "primary": "designGraphics",
@@ -3796,6 +4168,10 @@
       "primary": "utilities",
       "secondary": []
     },
+    "empoche": {
+      "primary": "productivity",
+      "secondary": []
+    },
     "enclave": {
       "primary": "securityPrivacy",
       "secondary": []
@@ -3888,6 +4264,14 @@
       "primary": "audioMusic",
       "secondary": []
     },
+    "equibop": {
+      "primary": "communication",
+      "secondary": []
+    },
+    "equinox": {
+      "primary": "screensaverWallpaper",
+      "secondary": []
+    },
     "es-de": {
       "primary": "games",
       "secondary": []
@@ -3930,6 +4314,10 @@
       "primary": "menuBar",
       "secondary": []
     },
+    "eurkey-next": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "eusamanager": {
       "primary": "financeCrypto",
       "secondary": []
@@ -3962,6 +4350,12 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "executor": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "exelearning": {
       "primary": "scienceEducation",
       "secondary": []
@@ -3969,6 +4363,12 @@
     "exifrenamer": {
       "primary": "utilities",
       "secondary": []
+    },
+    "exo": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "expandrive": {
       "primary": "cloudStorage",
@@ -3989,6 +4389,12 @@
     "expressvpn": {
       "primary": "securityPrivacy",
       "secondary": []
+    },
+    "extradock": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
     },
     "f-bar": {
       "primary": "developerTools",
@@ -4050,9 +4456,27 @@
       "primary": "audioMusic",
       "secondary": []
     },
+    "fabric-app": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "facescreen": {
+      "primary": "videoMedia",
+      "secondary": [
+        "communication"
+      ]
+    },
     "factor": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "factory": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "fanny": {
       "primary": "menuBar",
@@ -4136,6 +4560,10 @@
     },
     "ff-works": {
       "primary": "videoMedia",
+      "secondary": []
+    },
+    "fidelity-trader+": {
+      "primary": "financeCrypto",
       "secondary": []
     },
     "fido2-manage": {
@@ -4334,6 +4762,12 @@
       "primary": "browsers",
       "secondary": []
     },
+    "flow5": {
+      "primary": "scienceEducation",
+      "secondary": [
+        "designGraphics"
+      ]
+    },
     "flowdown": {
       "primary": "productivity",
       "secondary": [
@@ -4359,6 +4793,12 @@
     "fluid": {
       "primary": "utilities",
       "secondary": []
+    },
+    "fluidvoice": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "fluor": {
       "primary": "utilities",
@@ -4393,10 +4833,6 @@
       "secondary": []
     },
     "fmail": {
-      "primary": "communication",
-      "secondary": []
-    },
-    "fmail2": {
       "primary": "communication",
       "secondary": []
     },
@@ -4566,6 +5002,10 @@
       "primary": "audioMusic",
       "secondary": []
     },
+    "fredm-fuse": {
+      "primary": "games",
+      "secondary": []
+    },
     "free-download-manager": {
       "primary": "utilities",
       "secondary": []
@@ -4678,10 +5118,6 @@
     },
     "fspy": {
       "primary": "designGraphics",
-      "secondary": []
-    },
-    "ftdi-vcp-driver": {
-      "primary": "utilities",
       "secondary": []
     },
     "fujifilm-tether-app": {
@@ -4830,6 +5266,12 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "general-software-fresh": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "genesis-plus": {
       "primary": "games",
       "secondary": []
@@ -4845,6 +5287,12 @@
     "geoda": {
       "primary": "scienceEducation",
       "secondary": []
+    },
+    "geolibre": {
+      "primary": "scienceEducation",
+      "secondary": [
+        "utilities"
+      ]
     },
     "geomap": {
       "primary": "scienceEducation",
@@ -4896,9 +5344,22 @@
       "primary": "browsers",
       "secondary": []
     },
+    "ghostpepper": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "securityPrivacy"
+      ]
+    },
     "ghostty": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "ghostvm": {
+      "primary": "developerTools",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "gifox": {
       "primary": "utilities",
@@ -4917,6 +5378,10 @@
       "secondary": []
     },
     "gitbutler": {
+      "primary": "developerTools",
+      "secondary": []
+    },
+    "gitcomet": {
       "primary": "developerTools",
       "secondary": []
     },
@@ -4939,6 +5404,12 @@
     "github": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "github-copilot-app": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "github-copilot-for-xcode": {
       "primary": "developerTools",
@@ -5000,6 +5471,12 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "gnome": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "gns3": {
       "primary": "developerTools",
       "secondary": []
@@ -5015,6 +5492,12 @@
     "go-server": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "go2tv": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
     },
     "go64": {
       "primary": "utilities",
@@ -5080,6 +5563,12 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "google-gemini": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
     "google-japanese-ime": {
       "primary": "utilities",
       "secondary": []
@@ -5098,8 +5587,8 @@
       "primary": "games",
       "secondary": []
     },
-    "gosign": {
-      "primary": "productivity",
+    "gopher64": {
+      "primary": "games",
       "secondary": []
     },
     "gotiengviet": {
@@ -5147,6 +5636,10 @@
       "secondary": []
     },
     "graalvm-jdk": {
+      "primary": "developerTools",
+      "secondary": []
+    },
+    "gram": {
       "primary": "developerTools",
       "secondary": []
     },
@@ -5200,6 +5693,13 @@
         "developerTools"
       ]
     },
+    "greensignal": {
+      "primary": "utilities",
+      "secondary": [
+        "communication",
+        "menuBar"
+      ]
+    },
     "gretl": {
       "primary": "scienceEducation",
       "secondary": []
@@ -5220,16 +5720,24 @@
       "primary": "utilities",
       "secondary": []
     },
+    "grok-build": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "groove-omnidialer": {
+      "primary": "communication",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "grs-bluewallet": {
       "primary": "financeCrypto",
       "secondary": []
     },
     "guilded": {
       "primary": "communication",
-      "secondary": []
-    },
-    "guitar-pro": {
-      "primary": "audioMusic",
       "secondary": []
     },
     "gureumkim": {
@@ -5298,9 +5806,27 @@
       "primary": "utilities",
       "secondary": []
     },
+    "happ": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "happymac": {
       "primary": "utilities",
       "secondary": []
+    },
+    "harper-desktop": {
+      "primary": "productivity",
+      "secondary": [
+        "developerTools"
+      ]
+    },
+    "harvest": {
+      "primary": "productivity",
+      "secondary": [
+        "menuBar"
+      ]
     },
     "hazel": {
       "primary": "productivity",
@@ -5322,9 +5848,11 @@
         "developerTools"
       ]
     },
-    "hdhomerun": {
-      "primary": "videoMedia",
-      "secondary": []
+    "headlamp": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "headset": {
       "primary": "audioMusic",
@@ -5339,10 +5867,6 @@
       "secondary": [
         "ai"
       ]
-    },
-    "heimdall-suite": {
-      "primary": "utilities",
-      "secondary": []
     },
     "helio": {
       "primary": "audioMusic",
@@ -5422,6 +5946,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "hive-app": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "hma-vpn": {
       "primary": "securityPrivacy",
       "secondary": []
@@ -5447,6 +5977,12 @@
     "hookmark": {
       "primary": "productivity",
       "secondary": []
+    },
+    "hop": {
+      "primary": "productivity",
+      "secondary": [
+        "officeTools"
+      ]
     },
     "hopper-disassembler": {
       "primary": "developerTools",
@@ -5507,12 +6043,6 @@
     "hubstaff": {
       "primary": "productivity",
       "secondary": []
-    },
-    "huggingchat": {
-      "primary": "productivity",
-      "secondary": [
-        "ai"
-      ]
     },
     "huly": {
       "primary": "productivity",
@@ -5604,6 +6134,10 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "ibm-notifier": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "ibored": {
       "primary": "developerTools",
       "secondary": []
@@ -5611,6 +6145,12 @@
     "icab": {
       "primary": "browsers",
       "secondary": []
+    },
+    "icanhazshortcut": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
     },
     "icollections": {
       "primary": "productivity",
@@ -5647,6 +6187,12 @@
     "idagio": {
       "primary": "audioMusic",
       "secondary": []
+    },
+    "idevice-pair": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "idrive": {
       "primary": "cloudStorage",
@@ -5724,6 +6270,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "incident-io": {
+      "primary": "developerTools",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "infinidesk": {
       "primary": "utilities",
       "secondary": []
@@ -5733,6 +6285,10 @@
       "secondary": [
         "utilities"
       ]
+    },
+    "infocert-sign": {
+      "primary": "productivity",
+      "secondary": []
     },
     "inform": {
       "primary": "developerTools",
@@ -5765,6 +6321,13 @@
     "input-source-pro": {
       "primary": "utilities",
       "secondary": []
+    },
+    "input0": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "utilities"
+      ]
     },
     "inso": {
       "primary": "developerTools",
@@ -5806,8 +6369,16 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "intellij-idea-oss": {
+      "primary": "developerTools",
+      "secondary": []
+    },
     "internxt-drive": {
       "primary": "cloudStorage",
+      "secondary": []
+    },
+    "intiface-central": {
+      "primary": "utilities",
       "secondary": []
     },
     "intune-company-portal": {
@@ -5844,12 +6415,20 @@
       "primary": "menuBar",
       "secondary": []
     },
+    "iplay": {
+      "primary": "videoMedia",
+      "secondary": []
+    },
     "ipremoteutility": {
       "primary": "utilities",
       "secondary": []
     },
     "ipsecuritas": {
       "primary": "securityPrivacy",
+      "secondary": []
+    },
+    "iptvnator": {
+      "primary": "videoMedia",
       "secondary": []
     },
     "ipvanish-vpn": {
@@ -5934,6 +6513,12 @@
     "itsycal": {
       "primary": "menuBar",
       "secondary": []
+    },
+    "itsytv": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
     },
     "itunes-producer": {
       "primary": "productivity",
@@ -6081,6 +6666,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "jetbrains-air": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "jetbrains-gateway": {
       "primary": "developerTools",
       "secondary": []
@@ -6104,6 +6695,12 @@
     "jgrasp": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "jiba": {
+      "primary": "audioMusic",
+      "secondary": [
+        "utilities"
+      ]
     },
     "jiggler": {
       "primary": "utilities",
@@ -6261,6 +6858,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "kde-connect": {
+      "primary": "utilities",
+      "secondary": [
+        "communication"
+      ]
+    },
     "kdenlive": {
       "primary": "videoMedia",
       "secondary": []
@@ -6377,6 +6980,12 @@
       "primary": "securityPrivacy",
       "secondary": []
     },
+    "keyscreen": {
+      "primary": "utilities",
+      "secondary": [
+        "videoMedia"
+      ]
+    },
     "keysmith": {
       "primary": "productivity",
       "secondary": []
@@ -6400,6 +7009,13 @@
     "kilohearts-installer": {
       "primary": "audioMusic",
       "secondary": []
+    },
+    "kimi": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "communication"
+      ]
     },
     "kimis": {
       "primary": "communication",
@@ -6493,6 +7109,12 @@
         "ai"
       ]
     },
+    "koharu": {
+      "primary": "designGraphics",
+      "secondary": [
+        "ai"
+      ]
+    },
     "komet": {
       "primary": "developerTools",
       "secondary": []
@@ -6511,6 +7133,10 @@
     },
     "kopiaui": {
       "primary": "utilities",
+      "secondary": []
+    },
+    "kotlin-lsp": {
+      "primary": "developerTools",
       "secondary": []
     },
     "kotlin-native": {
@@ -6533,6 +7159,10 @@
     },
     "ksnip": {
       "primary": "utilities",
+      "secondary": []
+    },
+    "kstars": {
+      "primary": "scienceEducation",
       "secondary": []
     },
     "kuaitie": {
@@ -6693,6 +7323,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "letos": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "lets": {
       "primary": "designGraphics",
       "secondary": []
@@ -6716,6 +7352,12 @@
     "libcblite-community": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "libifd-cyberjack": {
+      "primary": "utilities",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "libndi": {
       "primary": "developerTools",
@@ -6773,13 +7415,7 @@
       "primary": "videoMedia",
       "secondary": []
     },
-    "limitless": {
-      "primary": "productivity",
-      "secondary": [
-        "ai"
-      ]
-    },
-    "linear-linear": {
+    "linear": {
       "primary": "developerTools",
       "secondary": [
         "productivity"
@@ -6833,7 +7469,7 @@
       "primary": "designGraphics",
       "secondary": []
     },
-    "llamabarn": {
+    "llama-app": {
       "primary": "menuBar",
       "secondary": []
     },
@@ -7003,6 +7639,12 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "ltx-desktop": {
+      "primary": "videoMedia",
+      "secondary": [
+        "ai"
+      ]
+    },
     "luanti": {
       "primary": "games",
       "secondary": []
@@ -7014,6 +7656,12 @@
     "lulu": {
       "primary": "securityPrivacy",
       "secondary": []
+    },
+    "lumide": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "luminance-hdr": {
       "primary": "designGraphics",
@@ -7161,6 +7809,18 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "macmd-viewer": {
+      "primary": "productivity",
+      "secondary": [
+        "developerTools"
+      ]
+    },
+    "macmediakeyforwarder": {
+      "primary": "utilities",
+      "secondary": [
+        "audioMusic"
+      ]
+    },
     "macpacker": {
       "primary": "utilities",
       "secondary": []
@@ -7168,6 +7828,13 @@
     "macpar-deluxe": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "macparakeet": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities",
+        "ai"
+      ]
     },
     "macpass": {
       "primary": "securityPrivacy",
@@ -7188,6 +7855,12 @@
     "macs-fan-control": {
       "primary": "utilities",
       "secondary": []
+    },
+    "macshot": {
+      "primary": "designGraphics",
+      "secondary": [
+        "utilities"
+      ]
     },
     "macskk": {
       "primary": "utilities",
@@ -7213,7 +7886,17 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "mactools": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "mactracker": {
+      "primary": "utilities",
+      "secondary": []
+    },
+    "macusb": {
       "primary": "utilities",
       "secondary": []
     },
@@ -7251,6 +7934,13 @@
     "maestral": {
       "primary": "cloudStorage",
       "secondary": []
+    },
+    "maestri": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "developerTools"
+      ]
     },
     "maestro": {
       "primary": "developerTools",
@@ -7346,6 +8036,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "manus": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
     "marathon": {
       "primary": "games",
       "secondary": []
@@ -7400,6 +8096,12 @@
       "primary": "productivity",
       "secondary": []
     },
+    "masscode": {
+      "primary": "developerTools",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "massreplaceit": {
       "primary": "utilities",
       "secondary": []
@@ -7411,6 +8113,12 @@
     "mate-translate": {
       "primary": "productivity",
       "secondary": []
+    },
+    "mater": {
+      "primary": "menuBar",
+      "secondary": [
+        "productivity"
+      ]
     },
     "material-maker": {
       "primary": "designGraphics",
@@ -7502,9 +8210,22 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "meetily": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "communication"
+      ]
+    },
     "meetingbar": {
       "primary": "menuBar",
       "secondary": []
+    },
+    "meetmic": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "mega": {
       "primary": "scienceEducation",
@@ -7550,11 +8271,11 @@
       "primary": "productivity",
       "secondary": []
     },
-    "memory-clean-3": {
+    "memory-cleaner": {
       "primary": "utilities",
       "secondary": []
     },
-    "memory-cleaner": {
+    "memory-meter-3": {
       "primary": "utilities",
       "secondary": []
     },
@@ -7600,6 +8321,12 @@
       "primary": "communication",
       "secondary": []
     },
+    "mesh": {
+      "primary": "productivity",
+      "secondary": [
+        "communication"
+      ]
+    },
     "meshlab": {
       "primary": "scienceEducation",
       "secondary": []
@@ -7610,6 +8337,10 @@
     },
     "meta-quest-developer-hub": {
       "primary": "developerTools",
+      "secondary": []
+    },
+    "meta-quest-remote-desktop": {
+      "primary": "utilities",
       "secondary": []
     },
     "metaimage": {
@@ -7652,6 +8383,10 @@
       "primary": "communication",
       "secondary": []
     },
+    "miaoyan": {
+      "primary": "productivity",
+      "secondary": []
+    },
     "micro-sniff": {
       "primary": "utilities",
       "secondary": []
@@ -7663,6 +8398,12 @@
     "microblog": {
       "primary": "communication",
       "secondary": []
+    },
+    "microsoft-365-copilot": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "microsoft-auto-update": {
       "primary": "officeTools",
@@ -7705,6 +8446,12 @@
     "microsoft-powerpoint": {
       "primary": "officeTools",
       "secondary": []
+    },
+    "microsoft-remote-help": {
+      "primary": "utilities",
+      "secondary": [
+        "communication"
+      ]
     },
     "microsoft-teams": {
       "primary": "communication",
@@ -7780,6 +8527,10 @@
         "developerTools"
       ]
     },
+    "mindmanager": {
+      "primary": "productivity",
+      "secondary": []
+    },
     "mindmaster-cn": {
       "primary": "productivity",
       "secondary": []
@@ -7848,6 +8599,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "mirai": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "miro": {
       "primary": "communication",
       "secondary": [
@@ -7865,6 +8622,12 @@
     "mist": {
       "primary": "utilities",
       "secondary": []
+    },
+    "mister-plimsoll": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
     },
     "mitmproxy": {
       "primary": "developerTools",
@@ -7895,6 +8658,12 @@
     "mixxx": {
       "primary": "audioMusic",
       "secondary": []
+    },
+    "mkvtoolnix-app": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
     },
     "mkvtools": {
       "primary": "videoMedia",
@@ -7933,6 +8702,12 @@
     "modrinth": {
       "primary": "games",
       "secondary": []
+    },
+    "mole-app": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
     },
     "molotov": {
       "primary": "videoMedia",
@@ -8043,6 +8818,12 @@
     "morisawa-desktop-manager": {
       "primary": "utilities",
       "secondary": []
+    },
+    "mos": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
     },
     "mosaic": {
       "primary": "utilities",
@@ -8167,6 +8948,23 @@
     "mucommander": {
       "primary": "utilities",
       "secondary": []
+    },
+    "mudlet": {
+      "primary": "games",
+      "secondary": []
+    },
+    "muesli": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "audioMusic"
+      ]
+    },
+    "mujoco": {
+      "primary": "scienceEducation",
+      "secondary": [
+        "developerTools"
+      ]
     },
     "mullvad-browser": {
       "primary": "browsers",
@@ -8404,6 +9202,10 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "navigator": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "navigraph-charts": {
       "primary": "games",
       "secondary": []
@@ -8462,10 +9264,6 @@
       "primary": "developerTools",
       "secondary": []
     },
-    "netdownloadhelpercoapp": {
-      "primary": "utilities",
-      "secondary": []
-    },
     "neteasemusic": {
       "primary": "audioMusic",
       "secondary": []
@@ -8501,6 +9299,12 @@
     "network-radar": {
       "primary": "utilities",
       "secondary": []
+    },
+    "netxms-console": {
+      "primary": "utilities",
+      "secondary": [
+        "developerTools"
+      ]
     },
     "nexonplug": {
       "primary": "games",
@@ -8541,6 +9345,13 @@
     "nightshade": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "nimbalyst": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai",
+        "productivity"
+      ]
     },
     "nimble-commander": {
       "primary": "utilities",
@@ -8616,9 +9427,22 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "nostalgiapp": {
+      "primary": "games",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "nota": {
       "primary": "productivity",
       "secondary": []
+    },
+    "notchi": {
+      "primary": "menuBar",
+      "secondary": [
+        "developerTools",
+        "ai"
+      ]
     },
     "notchnook": {
       "primary": "utilities",
@@ -8657,6 +9481,12 @@
       "primary": "productivity",
       "secondary": []
     },
+    "notion-cli": {
+      "primary": "developerTools",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "notion-mail": {
       "primary": "communication",
       "secondary": []
@@ -8685,10 +9515,6 @@
       "primary": "other",
       "secondary": []
     },
-    "novation-play": {
-      "primary": "audioMusic",
-      "secondary": []
-    },
     "now-tv-player": {
       "primary": "videoMedia",
       "secondary": []
@@ -8703,10 +9529,6 @@
     },
     "nrf-connect": {
       "primary": "developerTools",
-      "secondary": []
-    },
-    "nrfutil": {
-      "primary": "designGraphics",
       "secondary": []
     },
     "nteract": {
@@ -8745,9 +9567,19 @@
       "primary": "games",
       "secondary": []
     },
+    "nvidia-nsight-compute": {
+      "primary": "developerTools",
+      "secondary": []
+    },
     "nvidia-nsight-systems": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "nvidia-sync": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "nvs": {
       "primary": "developerTools",
@@ -8758,6 +9590,10 @@
       "secondary": [
         "designGraphics"
       ]
+    },
+    "ob-xf": {
+      "primary": "audioMusic",
+      "secondary": []
     },
     "objectivesharpie": {
       "primary": "developerTools",
@@ -8884,6 +9720,12 @@
       "primary": "financeCrypto",
       "secondary": []
     },
+    "onexrayse": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "onionshare": {
       "primary": "communication",
       "secondary": []
@@ -8928,13 +9770,33 @@
         "scienceEducation"
       ]
     },
+    "open-design": {
+      "primary": "designGraphics",
+      "secondary": [
+        "ai",
+        "developerTools"
+      ]
+    },
     "open-eid": {
       "primary": "utilities",
       "secondary": []
     },
+    "open-island": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai",
+        "menuBar"
+      ]
+    },
     "open-video-downloader": {
       "primary": "videoMedia",
       "secondary": []
+    },
+    "open-webui": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "openaudible": {
       "primary": "audioMusic",
@@ -8946,6 +9808,12 @@
     },
     "opencat": {
       "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "openchamber": {
+      "primary": "developerTools",
       "secondary": [
         "ai"
       ]
@@ -8979,6 +9847,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "opencpn": {
+      "primary": "scienceEducation",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "openforis-collect": {
       "primary": "developerTools",
       "secondary": [
@@ -8989,9 +9863,21 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "openhuman": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
     "openhv": {
       "primary": "games",
       "secondary": []
+    },
+    "openin": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
     },
     "openineditor-lite": {
       "primary": "utilities",
@@ -9013,9 +9899,19 @@
       "primary": "utilities",
       "secondary": []
     },
+    "openlogi": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "openmtp": {
       "primary": "utilities",
       "secondary": []
+    },
+    "openpencil": {
+      "primary": "designGraphics",
+      "secondary": [
+        "ai"
+      ]
     },
     "openpht": {
       "primary": "videoMedia",
@@ -9034,6 +9930,12 @@
     "openrocket": {
       "primary": "scienceEducation",
       "secondary": []
+    },
+    "opensc-app": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
     },
     "openshot-video-editor": {
       "primary": "videoMedia",
@@ -9061,6 +9963,13 @@
       "primary": "games",
       "secondary": []
     },
+    "openusage": {
+      "primary": "menuBar",
+      "secondary": [
+        "developerTools",
+        "ai"
+      ]
+    },
     "openvanilla": {
       "primary": "utilities",
       "secondary": []
@@ -9072,6 +9981,12 @@
     "openwebstart": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "openwork": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "openzfs": {
       "primary": "utilities",
@@ -9131,6 +10046,12 @@
     "orcaslicer": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "orchard": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "origami-studio": {
       "primary": "designGraphics",
@@ -9232,6 +10153,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "overtone-analyzer": {
+      "primary": "audioMusic",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "overview": {
       "primary": "utilities",
       "secondary": []
@@ -9330,9 +10257,21 @@
       "primary": "productivity",
       "secondary": []
     },
+    "palmier-pro": {
+      "primary": "videoMedia",
+      "secondary": [
+        "ai"
+      ]
+    },
     "pandora": {
       "primary": "audioMusic",
       "secondary": []
+    },
+    "pangolin": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
     },
     "panoply": {
       "primary": "scienceEducation",
@@ -9344,6 +10283,10 @@
     },
     "paper": {
       "primary": "screensaverWallpaper",
+      "secondary": []
+    },
+    "paper-design": {
+      "primary": "designGraphics",
       "secondary": []
     },
     "papercut-mobility-print-client": {
@@ -9390,6 +10333,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "paranoia-file-text-encryption": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "paraview": {
       "primary": "scienceEducation",
       "secondary": []
@@ -9410,6 +10359,12 @@
       "primary": "productivity",
       "secondary": [
         "utilities"
+      ]
+    },
+    "paseo": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
       ]
     },
     "passepartout": {
@@ -9516,6 +10471,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "pencil2d": {
+      "primary": "designGraphics",
+      "secondary": [
+        "videoMedia"
+      ]
+    },
     "peninsula": {
       "primary": "utilities",
       "secondary": []
@@ -9539,6 +10500,12 @@
     "pgadmin4": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "pgen": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "philips-hue-sync": {
       "primary": "utilities",
@@ -9670,6 +10637,13 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "ping-island": {
+      "primary": "menuBar",
+      "secondary": [
+        "developerTools",
+        "ai"
+      ]
+    },
     "pingid": {
       "primary": "securityPrivacy",
       "secondary": []
@@ -9694,6 +10668,12 @@
       "primary": "menuBar",
       "secondary": []
     },
+    "pique": {
+      "primary": "utilities",
+      "secondary": [
+        "developerTools"
+      ]
+    },
     "pitch": {
       "primary": "productivity",
       "secondary": []
@@ -9716,6 +10696,13 @@
       "primary": "utilities",
       "secondary": []
     },
+    "plamo-translate": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "scienceEducation"
+      ]
+    },
     "planet": {
       "primary": "developerTools",
       "secondary": []
@@ -9726,6 +10713,10 @@
     },
     "plasticscm-cloud-edition": {
       "primary": "developerTools",
+      "secondary": []
+    },
+    "platinum-notes": {
+      "primary": "audioMusic",
       "secondary": []
     },
     "plaud": {
@@ -9788,6 +10779,12 @@
         "developerTools"
       ]
     },
+    "pluralplay-flclashx": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "plus42-binary": {
       "primary": "scienceEducation",
       "secondary": []
@@ -9799,6 +10796,12 @@
     "pock": {
       "primary": "menuBar",
       "secondary": []
+    },
+    "pocket-bard": {
+      "primary": "audioMusic",
+      "secondary": [
+        "games"
+      ]
     },
     "pocket-casts": {
       "primary": "audioMusic",
@@ -9906,7 +10909,7 @@
       "primary": "communication",
       "secondary": []
     },
-    "postgres-unofficial": {
+    "postgres-app": {
       "primary": "developerTools",
       "secondary": []
     },
@@ -9943,6 +10946,12 @@
     "power-manager": {
       "primary": "utilities",
       "secondary": []
+    },
+    "power-monitor": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
     },
     "powerpanel": {
       "primary": "utilities",
@@ -9995,6 +11004,12 @@
     "presentation": {
       "primary": "productivity",
       "secondary": []
+    },
+    "presentify": {
+      "primary": "productivity",
+      "secondary": [
+        "designGraphics"
+      ]
     },
     "presonus-universal-control": {
       "primary": "audioMusic",
@@ -10140,6 +11155,12 @@
       "primary": "communication",
       "secondary": []
     },
+    "proton-meet": {
+      "primary": "communication",
+      "secondary": [
+        "securityPrivacy"
+      ]
+    },
     "proton-pass": {
       "primary": "utilities",
       "secondary": []
@@ -10184,6 +11205,12 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "psiphon-conduit": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "psychopy": {
       "primary": "scienceEducation",
       "secondary": []
@@ -10214,6 +11241,12 @@
       "primary": "games",
       "secondary": []
     },
+    "puremac": {
+      "primary": "utilities",
+      "secondary": [
+        "securityPrivacy"
+      ]
+    },
     "purevpn": {
       "primary": "securityPrivacy",
       "secondary": []
@@ -10227,6 +11260,10 @@
       "secondary": [
         "ai"
       ]
+    },
+    "pycharm-oss": {
+      "primary": "developerTools",
+      "secondary": []
     },
     "pym-player": {
       "primary": "videoMedia",
@@ -10292,9 +11329,11 @@
       "primary": "utilities",
       "secondary": []
     },
-    "qlvideo": {
+    "qlmarkdown": {
       "primary": "utilities",
-      "secondary": []
+      "secondary": [
+        "developerTools"
+      ]
     },
     "qobuz": {
       "primary": "audioMusic",
@@ -10380,6 +11419,10 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "quicklook-video": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "quicksilver": {
       "primary": "utilities",
       "secondary": [
@@ -10389,12 +11432,6 @@
     "quicktune": {
       "primary": "audioMusic",
       "secondary": []
-    },
-    "quickwhisper": {
-      "primary": "productivity",
-      "secondary": [
-        "ai"
-      ]
     },
     "quiet": {
       "primary": "communication",
@@ -10407,7 +11444,7 @@
       "primary": "productivity",
       "secondary": []
     },
-    "quit-all": {
+    "quitall": {
       "primary": "utilities",
       "secondary": []
     },
@@ -10427,6 +11464,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "r-rig-app": {
+      "primary": "developerTools",
+      "secondary": [
+        "scienceEducation"
+      ]
+    },
     "racket": {
       "primary": "developerTools",
       "secondary": []
@@ -10435,12 +11478,22 @@
       "primary": "menuBar",
       "secondary": []
     },
+    "radial": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "radio-silence": {
       "primary": "securityPrivacy",
       "secondary": []
     },
     "radiola": {
       "primary": "audioMusic",
+      "secondary": []
+    },
+    "radix": {
+      "primary": "utilities",
       "secondary": []
     },
     "raiderio": {
@@ -10504,6 +11557,12 @@
         "ai"
       ]
     },
+    "rayon": {
+      "primary": "designGraphics",
+      "secondary": [
+        "ai"
+      ]
+    },
     "raze": {
       "primary": "games",
       "secondary": []
@@ -10522,6 +11581,12 @@
       "primary": "utilities",
       "secondary": [
         "cloudStorage"
+      ]
+    },
+    "rcmd": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
       ]
     },
     "react-native-debugger": {
@@ -10554,10 +11619,6 @@
     },
     "readyapi": {
       "primary": "developerTools",
-      "secondary": []
-    },
-    "realforce": {
-      "primary": "utilities",
       "secondary": []
     },
     "realvnc-connect": {
@@ -10632,6 +11693,10 @@
       "primary": "audioMusic",
       "secondary": []
     },
+    "remanager": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "remember-the-milk": {
       "primary": "productivity",
       "secondary": []
@@ -10667,6 +11732,12 @@
     "removebg": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "renameclick": {
+      "primary": "utilities",
+      "secondary": [
+        "ai"
+      ]
     },
     "renamer": {
       "primary": "utilities",
@@ -10800,6 +11871,10 @@
     },
     "revolver-office": {
       "primary": "officeTools",
+      "secondary": []
+    },
+    "revpdf-editor": {
+      "primary": "productivity",
       "secondary": []
     },
     "rewritebar": {
@@ -10936,6 +12011,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "rockxy": {
+      "primary": "developerTools",
+      "secondary": [
+        "securityPrivacy"
+      ]
+    },
     "rode-central": {
       "primary": "other",
       "secondary": []
@@ -10984,6 +12065,12 @@
       "primary": "other",
       "secondary": []
     },
+    "rowboat": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
     "rowmote-helper": {
       "primary": "utilities",
       "secondary": []
@@ -11016,10 +12103,20 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "runtimeviewer": {
+      "primary": "developerTools",
+      "secondary": []
+    },
     "runway": {
       "primary": "designGraphics",
       "secondary": [
         "ai"
+      ]
+    },
+    "rustcast": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
       ]
     },
     "rustdesk": {
@@ -11044,10 +12141,6 @@
     },
     "safe-exam-browser": {
       "primary": "browsers",
-      "secondary": []
-    },
-    "safeincloud-password-manager": {
-      "primary": "securityPrivacy",
       "secondary": []
     },
     "sage": {
@@ -11142,10 +12235,6 @@
       "primary": "scienceEducation",
       "secondary": []
     },
-    "scidvsmac": {
-      "primary": "games",
-      "secondary": []
-    },
     "scilab": {
       "primary": "scienceEducation",
       "secondary": []
@@ -11185,6 +12274,12 @@
     "screenfocus": {
       "primary": "utilities",
       "secondary": []
+    },
+    "screenkite": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
     },
     "screenmemory": {
       "primary": "utilities",
@@ -11258,6 +12353,10 @@
       "primary": "productivity",
       "secondary": []
     },
+    "seamly2d": {
+      "primary": "designGraphics",
+      "secondary": []
+    },
     "second-life-viewer": {
       "primary": "designGraphics",
       "secondary": []
@@ -11274,7 +12373,13 @@
       "primary": "securityPrivacy",
       "secondary": []
     },
-    "segger-embedded-studio-for-arm": {
+    "seekfast": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
+    },
+    "segger-embedded-studio": {
       "primary": "developerTools",
       "secondary": []
     },
@@ -11310,10 +12415,6 @@
       "primary": "utilities",
       "secondary": []
     },
-    "send-to-kindle": {
-      "primary": "utilities",
-      "secondary": []
-    },
     "sensei": {
       "primary": "utilities",
       "secondary": []
@@ -11342,6 +12443,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "server-box": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "serverbuddy": {
       "primary": "developerTools",
       "secondary": []
@@ -11353,6 +12460,12 @@
     "session": {
       "primary": "communication",
       "secondary": []
+    },
+    "session-manager-plugin": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "sessionrestore": {
       "primary": "productivity",
@@ -11369,6 +12482,13 @@
     "sfm": {
       "primary": "securityPrivacy",
       "secondary": []
+    },
+    "shade": {
+      "primary": "cloudStorage",
+      "secondary": [
+        "ai",
+        "videoMedia"
+      ]
     },
     "shadow": {
       "primary": "games",
@@ -11392,6 +12512,12 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "sharefile": {
+      "primary": "cloudStorage",
+      "secondary": [
+        "securityPrivacy"
+      ]
+    },
     "sharemouse": {
       "primary": "utilities",
       "secondary": []
@@ -11408,12 +12534,16 @@
       "primary": "utilities",
       "secondary": []
     },
-    "shell360": {
+    "sherlock-app": {
       "primary": "developerTools",
       "secondary": []
     },
-    "sherlock-app": {
-      "primary": "developerTools",
+    "shichizip": {
+      "primary": "utilities",
+      "secondary": []
+    },
+    "shichizip-zs": {
+      "primary": "utilities",
       "secondary": []
     },
     "shield": {
@@ -11521,6 +12651,12 @@
     "silicon-labs-vcp-driver": {
       "primary": "other",
       "secondary": []
+    },
+    "silkypix-developer-studio-se": {
+      "primary": "designGraphics",
+      "secondary": [
+        "utilities"
+      ]
     },
     "silnite": {
       "primary": "securityPrivacy",
@@ -11665,6 +12801,10 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "slashy": {
+      "primary": "communication",
+      "secondary": []
+    },
     "sleek-app": {
       "primary": "productivity",
       "secondary": []
@@ -11672,6 +12812,12 @@
     "sleep-aid": {
       "primary": "utilities",
       "secondary": []
+    },
+    "slicer": {
+      "primary": "scienceEducation",
+      "secondary": [
+        "designGraphics"
+      ]
     },
     "slidepad": {
       "primary": "browsers",
@@ -11725,6 +12871,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "smoothcapture": {
+      "primary": "videoMedia",
+      "secondary": [
+        "designGraphics"
+      ]
+    },
     "smoothcsv": {
       "primary": "productivity",
       "secondary": []
@@ -11765,6 +12917,13 @@
       "primary": "utilities",
       "secondary": []
     },
+    "snapzy": {
+      "primary": "designGraphics",
+      "secondary": [
+        "menuBar",
+        "videoMedia"
+      ]
+    },
     "snes9x": {
       "primary": "games",
       "secondary": []
@@ -11772,6 +12931,12 @@
     "snipaste": {
       "primary": "utilities",
       "secondary": []
+    },
+    "snippety": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
     },
     "snowflake-snowsql": {
       "primary": "developerTools",
@@ -11836,6 +13001,12 @@
     "solvespace": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "sonarqube-cli": {
+      "primary": "developerTools",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "songkong": {
       "primary": "audioMusic",
@@ -11946,10 +13117,6 @@
       "primary": "menuBar",
       "secondary": []
     },
-    "spacesaver": {
-      "primary": "designGraphics",
-      "secondary": []
-    },
     "spacewalker": {
       "primary": "utilities",
       "secondary": []
@@ -11986,9 +13153,23 @@
       "primary": "financeCrypto",
       "secondary": []
     },
+    "spectra-app": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai",
+        "productivity"
+      ]
+    },
     "spectrolite": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "speechify-voice-ai": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "audioMusic"
+      ]
     },
     "speedify": {
       "primary": "securityPrivacy",
@@ -12029,6 +13210,12 @@
     "spline": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "spokenly": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "spotify": {
       "primary": "audioMusic",
@@ -12117,6 +13304,12 @@
     "ssh-config-editor": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "sshfs-mac": {
+      "primary": "utilities",
+      "secondary": [
+        "developerTools"
+      ]
     },
     "stability-matrix": {
       "primary": "designGraphics",
@@ -12252,6 +13445,16 @@
       "primary": "videoMedia",
       "secondary": []
     },
+    "stremio": {
+      "primary": "videoMedia",
+      "secondary": []
+    },
+    "stremioservice": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "stringz": {
       "primary": "developerTools",
       "secondary": []
@@ -12304,6 +13507,12 @@
       "primary": "other",
       "secondary": []
     },
+    "subtitle-studio": {
+      "primary": "videoMedia",
+      "secondary": [
+        "ai"
+      ]
+    },
     "sunlogincontrol": {
       "primary": "utilities",
       "secondary": []
@@ -12313,6 +13522,22 @@
       "secondary": []
     },
     "supacode": {
+      "primary": "developerTools",
+      "secondary": []
+    },
+    "supasidebar": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
+    },
+    "supaterm": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "super": {
       "primary": "developerTools",
       "secondary": []
     },
@@ -12528,6 +13753,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "syntax-highlight": {
+      "primary": "utilities",
+      "secondary": [
+        "developerTools"
+      ]
+    },
     "synthesia": {
       "primary": "audioMusic",
       "secondary": []
@@ -12543,6 +13774,12 @@
     "systhist": {
       "primary": "securityPrivacy",
       "secondary": []
+    },
+    "t3-code": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "tabby": {
       "primary": "developerTools",
@@ -12584,7 +13821,15 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "tablen": {
+      "primary": "developerTools",
+      "secondary": []
+    },
     "tableplus": {
+      "primary": "developerTools",
+      "secondary": []
+    },
+    "tablepro": {
       "primary": "developerTools",
       "secondary": []
     },
@@ -12641,6 +13886,12 @@
     "tandem": {
       "primary": "productivity",
       "secondary": []
+    },
+    "tangleguard-cli": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "taobao": {
       "primary": "productivity",
@@ -12736,10 +13987,6 @@
       "primary": "communication",
       "secondary": []
     },
-    "techsmith-capture": {
-      "primary": "utilities",
-      "secondary": []
-    },
     "teensy": {
       "primary": "utilities",
       "secondary": []
@@ -12788,9 +14035,19 @@
       "primary": "communication",
       "secondary": []
     },
+    "tencent-ugit": {
+      "primary": "developerTools",
+      "secondary": []
+    },
     "tentacle-sync-studio": {
       "primary": "audioMusic",
       "secondary": []
+    },
+    "terax": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "termius": {
       "primary": "developerTools",
@@ -13002,6 +14259,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "tikz-editor": {
+      "primary": "designGraphics",
+      "secondary": [
+        "developerTools"
+      ]
+    },
     "tiled": {
       "primary": "developerTools",
       "secondary": [
@@ -13086,6 +14349,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "tldraw": {
+      "primary": "designGraphics",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "tm-error-logger": {
       "primary": "utilities",
       "secondary": []
@@ -13106,9 +14375,19 @@
       "primary": "productivity",
       "secondary": []
     },
+    "todometer": {
+      "primary": "productivity",
+      "secondary": []
+    },
     "tofu": {
       "primary": "productivity",
       "secondary": []
+    },
+    "tolaria": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "toneprint": {
       "primary": "utilities",
@@ -13224,6 +14503,13 @@
       "primary": "audioMusic",
       "secondary": []
     },
+    "transcribex": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "audioMusic"
+      ]
+    },
     "transfer": {
       "primary": "developerTools",
       "secondary": []
@@ -13263,6 +14549,12 @@
     "trezor-suite": {
       "primary": "financeCrypto",
       "secondary": []
+    },
+    "trickster": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
     },
     "trilium-notes": {
       "primary": "productivity",
@@ -13311,6 +14603,18 @@
     "tuist": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "tuna": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
+    },
+    "tunarr": {
+      "primary": "videoMedia",
+      "secondary": [
+        "utilities"
+      ]
     },
     "tunein": {
       "primary": "audioMusic",
@@ -13408,6 +14712,12 @@
         "ai"
       ]
     },
+    "typewhisper": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
     "typinator": {
       "primary": "productivity",
       "secondary": []
@@ -13415,6 +14725,12 @@
     "typora": {
       "primary": "productivity",
       "secondary": []
+    },
+    "ua-connect": {
+      "primary": "audioMusic",
+      "secondary": [
+        "utilities"
+      ]
     },
     "ua-midi-control": {
       "primary": "audioMusic",
@@ -13460,6 +14776,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "ulaa": {
+      "primary": "browsers",
+      "secondary": [
+        "securityPrivacy"
+      ]
+    },
     "ulbow": {
       "primary": "developerTools",
       "secondary": []
@@ -13471,6 +14793,12 @@
     "ultimaker-cura": {
       "primary": "designGraphics",
       "secondary": []
+    },
+    "unblocked": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "unclack": {
       "primary": "utilities",
@@ -13486,6 +14814,12 @@
     },
     "ungoogled-chromium": {
       "primary": "browsers",
+      "secondary": [
+        "securityPrivacy"
+      ]
+    },
+    "uniclipboard": {
+      "primary": "productivity",
       "secondary": [
         "securityPrivacy"
       ]
@@ -13522,10 +14856,34 @@
       "primary": "utilities",
       "secondary": []
     },
+    "unity": {
+      "primary": "developerTools",
+      "secondary": [
+        "games"
+      ]
+    },
     "unity-hub": {
       "primary": "developerTools",
       "secondary": [
         "developerTools"
+      ]
+    },
+    "unity-ios-support-for-editor": {
+      "primary": "developerTools",
+      "secondary": [
+        "games"
+      ]
+    },
+    "unity-webgl-support-for-editor": {
+      "primary": "developerTools",
+      "secondary": [
+        "games"
+      ]
+    },
+    "unity-windows-support-for-editor": {
+      "primary": "developerTools",
+      "secondary": [
+        "games"
       ]
     },
     "universal-media-server": {
@@ -13620,6 +14978,12 @@
       "primary": "audioMusic",
       "secondary": []
     },
+    "valkey-admin": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "vallum": {
       "primary": "securityPrivacy",
       "secondary": []
@@ -13653,6 +15017,10 @@
       "secondary": [
         "communication"
       ]
+    },
+    "vcmi": {
+      "primary": "games",
+      "secondary": []
     },
     "vcv-rack": {
       "primary": "audioMusic",
@@ -13709,6 +15077,27 @@
     "viables": {
       "primary": "utilities",
       "secondary": []
+    },
+    "vibe-island": {
+      "primary": "menuBar",
+      "secondary": [
+        "developerTools",
+        "ai"
+      ]
+    },
+    "vibe-notch": {
+      "primary": "menuBar",
+      "secondary": [
+        "developerTools",
+        "ai"
+      ]
+    },
+    "vibeproxy": {
+      "primary": "developerTools",
+      "secondary": [
+        "menuBar",
+        "ai"
+      ]
     },
     "viber": {
       "primary": "communication",
@@ -13810,6 +15199,12 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "visual-paradigm-ce": {
+      "primary": "developerTools",
+      "secondary": [
+        "designGraphics"
+      ]
+    },
     "visual-studio-code": {
       "primary": "developerTools",
       "secondary": [
@@ -13870,6 +15265,13 @@
       "primary": "videoMedia",
       "secondary": []
     },
+    "vmlx": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "developerTools"
+      ]
+    },
     "vnc-server": {
       "primary": "utilities",
       "secondary": []
@@ -13878,18 +15280,32 @@
       "primary": "utilities",
       "secondary": []
     },
-    "vnote": {
-      "primary": "productivity",
-      "secondary": []
-    },
     "vocaster-hub": {
       "primary": "other",
       "secondary": []
+    },
+    "vocevista-video": {
+      "primary": "scienceEducation",
+      "secondary": [
+        "audioMusic"
+      ]
+    },
+    "vocevista-video-pro": {
+      "primary": "audioMusic",
+      "secondary": [
+        "scienceEducation"
+      ]
     },
     "voiceink": {
       "primary": "productivity",
       "secondary": [
         "ai"
+      ]
+    },
+    "voicemod": {
+      "primary": "audioMusic",
+      "secondary": [
+        "utilities"
       ]
     },
     "voicenotes": {
@@ -13919,10 +15335,6 @@
       "secondary": []
     },
     "volanta": {
-      "primary": "utilities",
-      "secondary": []
-    },
-    "volta-app": {
       "primary": "utilities",
       "secondary": []
     },
@@ -13984,6 +15396,10 @@
       "primary": "utilities",
       "secondary": []
     },
+    "vuze": {
+      "primary": "utilities",
+      "secondary": []
+    },
     "vv": {
       "primary": "developerTools",
       "secondary": []
@@ -14013,6 +15429,10 @@
       "secondary": []
     },
     "wallpaper-wizard": {
+      "primary": "screensaverWallpaper",
+      "secondary": []
+    },
+    "wallspace": {
       "primary": "screensaverWallpaper",
       "secondary": []
     },
@@ -14138,10 +15558,6 @@
       "primary": "cloudStorage",
       "secondary": []
     },
-    "weka": {
-      "primary": "scienceEducation",
-      "secondary": []
-    },
     "wetype": {
       "primary": "utilities",
       "secondary": []
@@ -14153,6 +15569,12 @@
     "whalebird": {
       "primary": "communication",
       "secondary": []
+    },
+    "whatcable": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
     },
     "whatroute": {
       "primary": "utilities",
@@ -14169,6 +15591,12 @@
     "whatsyoursign": {
       "primary": "securityPrivacy",
       "secondary": []
+    },
+    "whichspace": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
     },
     "whimsical": {
       "primary": "designGraphics",
@@ -14241,12 +15669,6 @@
     "windscribe": {
       "primary": "securityPrivacy",
       "secondary": []
-    },
-    "windsurf": {
-      "primary": "developerTools",
-      "secondary": [
-        "ai"
-      ]
     },
     "wing-personal": {
       "primary": "developerTools",
@@ -14394,6 +15816,12 @@
       "primary": "productivity",
       "secondary": []
     },
+    "worksheet-crafter": {
+      "primary": "scienceEducation",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "workspace-one-intelligent-hub": {
       "primary": "securityPrivacy",
       "secondary": []
@@ -14405,6 +15833,18 @@
     "wowup": {
       "primary": "games",
       "secondary": []
+    },
+    "wowup-cf": {
+      "primary": "utilities",
+      "secondary": [
+        "games"
+      ]
+    },
+    "wox": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
     },
     "wpsoffice": {
       "primary": "officeTools",
@@ -14433,6 +15873,12 @@
     "wxmacmolplt": {
       "primary": "scienceEducation",
       "secondary": []
+    },
+    "x-air-edit": {
+      "primary": "audioMusic",
+      "secondary": [
+        "utilities"
+      ]
     },
     "x-swiftformat": {
       "primary": "developerTools",
@@ -14468,6 +15914,10 @@
     },
     "xctu": {
       "primary": "developerTools",
+      "secondary": []
+    },
+    "xdeck": {
+      "primary": "communication",
       "secondary": []
     },
     "xee": {
@@ -14574,6 +16024,12 @@
       "primary": "productivity",
       "secondary": []
     },
+    "yakit": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "developerTools"
+      ]
+    },
     "yam-display": {
       "primary": "utilities",
       "secondary": []
@@ -14643,6 +16099,13 @@
     "yoink": {
       "primary": "utilities",
       "secondary": []
+    },
+    "yojam": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar",
+        "browsers"
+      ]
     },
     "yojimbo": {
       "primary": "productivity",
@@ -14813,6 +16276,12 @@
     "zulufx": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "zush": {
+      "primary": "utilities",
+      "secondary": [
+        "ai"
+      ]
     },
     "zwift": {
       "primary": "other",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -2,7 +2,7 @@
 _Generated 2026-07-06_
 
 ## Summary
-- 279 new casks classified
+- 281 new casks classified
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 13 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
@@ -26,285 +26,287 @@ _Generated 2026-07-06_
 ## New classifications
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `8bitdo-firmware-updater` | utilities | — | 0.50 | mock client: keyword match |
-| `agentsmesh` | utilities | — | 0.50 | mock client: keyword match |
-| `agentsview` | utilities | — | 0.50 | mock client: keyword match |
-| `airi` | utilities | — | 0.50 | mock client: keyword match |
-| `altar-ai` | developerTools | — | 0.50 | mock client: keyword match |
-| `altersend` | securityPrivacy | — | 0.50 | mock client: keyword match |
-| `amore` | developerTools | — | 0.50 | mock client: keyword match |
-| `annotate` | developerTools | — | 0.50 | mock client: keyword match |
-| `antigravity-cli` | developerTools | — | 0.50 | mock client: keyword match |
-| `antigravity-ide` | developerTools | — | 0.50 | mock client: keyword match |
-| `appgridmac` | utilities | — | 0.50 | mock client: keyword match |
-| `ariax` | developerTools | — | 0.50 | mock client: keyword match |
-| `aside` | developerTools | ai | 0.50 | mock client: keyword match |
-| `atoll` | utilities | — | 0.50 | mock client: keyword match |
-| `atomcode` | developerTools | — | 0.50 | mock client: keyword match |
-| `auto-subs` | developerTools | — | 0.50 | mock client: keyword match |
-| `autofirma` | developerTools | — | 0.50 | mock client: keyword match |
-| `backblaze-restore` | utilities | — | 0.50 | mock client: keyword match |
-| `baoliandeng` | developerTools | — | 0.50 | mock client: keyword match |
-| `baseline` | developerTools | — | 0.50 | mock client: keyword match |
-| `bettercapture` | audioMusic | — | 0.50 | mock client: keyword match |
-| `bettercmdtab` | utilities | — | 0.50 | mock client: keyword match |
-| `brave-origin` | browsers | — | 0.50 | mock client: keyword match |
-| `buzz` | developerTools | — | 0.50 | mock client: keyword match |
-| `cadran` | screensaverWallpaper | — | 0.50 | mock client: keyword match |
-| `caldigit-usb-hub-support-driver` | developerTools | — | 0.50 | mock client: keyword match |
-| `calendr` | developerTools | — | 0.50 | mock client: keyword match |
-| `cavalry` | designGraphics | — | 0.50 | mock client: keyword match |
-| `cc-pocket` | developerTools | — | 0.50 | mock client: keyword match |
-| `cc-switch` | developerTools | — | 0.50 | mock client: keyword match |
-| `chiri` | developerTools | — | 0.50 | mock client: keyword match |
-| `choragus` | developerTools | — | 0.50 | mock client: keyword match |
-| `chronoid` | financeCrypto | — | 0.50 | mock client: keyword match |
-| `clarify` | utilities | — | 0.50 | mock client: keyword match |
-| `claude-devtools` | developerTools | — | 0.50 | mock client: keyword match |
-| `clearance` | developerTools | — | 0.50 | mock client: keyword match |
-| `clickshare` | utilities | — | 0.50 | mock client: keyword match |
-| `cmux` | developerTools | — | 0.50 | mock client: keyword match |
-| `codeexpander` | developerTools | — | 0.50 | mock client: keyword match |
-| `connectiq-sdk-manager` | utilities | — | 0.50 | mock client: keyword match |
-| `copilot-language-server` | developerTools | — | 0.50 | mock client: keyword match |
-| `corelocationcli` | developerTools | — | 0.50 | mock client: keyword match |
-| `cotypist` | developerTools | — | 0.50 | mock client: keyword match |
-| `cpuinfo` | developerTools | — | 0.50 | mock client: keyword match |
-| `craft-agents` | developerTools | ai | 0.50 | mock client: keyword match |
-| `ctivo` | developerTools | — | 0.50 | mock client: keyword match |
-| `datadog-agent` | developerTools | — | 0.50 | mock client: keyword match |
-| `dbeaverteam` | utilities | — | 0.50 | mock client: keyword match |
-| `dbvr` | developerTools | — | 0.50 | mock client: keyword match |
-| `dbx` | developerTools | ai | 0.50 | mock client: keyword match |
-| `dcp-o-matic` | developerTools | — | 0.50 | mock client: keyword match |
-| `dcp-o-matic-batch-converter` | developerTools | — | 0.50 | mock client: keyword match |
-| `dcp-o-matic-combiner` | developerTools | — | 0.50 | mock client: keyword match |
-| `dcp-o-matic-disk-writer` | developerTools | — | 0.50 | mock client: keyword match |
-| `dcp-o-matic-editor` | developerTools | — | 0.50 | mock client: keyword match |
-| `dcp-o-matic-encode-server` | developerTools | — | 0.50 | mock client: keyword match |
-| `dcp-o-matic-kdm-creator` | developerTools | — | 0.50 | mock client: keyword match |
-| `dcp-o-matic-player` | developerTools | — | 0.50 | mock client: keyword match |
-| `dcp-o-matic-playlist-editor` | developerTools | — | 0.50 | mock client: keyword match |
-| `deadbolt` | developerTools | — | 0.50 | mock client: keyword match |
-| `devin-cli` | utilities | — | 0.50 | mock client: keyword match |
-| `dfu-blaster-pro` | utilities | — | 0.50 | mock client: keyword match |
-| `do-not-disturb` | utilities | — | 0.50 | mock client: keyword match |
-| `dockspace` | audioMusic | — | 0.50 | mock client: keyword match |
-| `dot` | utilities | — | 0.50 | mock client: keyword match |
-| `dotnet-reactor` | developerTools | — | 0.50 | mock client: keyword match |
-| `doxygen-app` | developerTools | — | 0.50 | mock client: keyword match |
-| `duo-desktop` | utilities | — | 0.50 | mock client: keyword match |
-| `dusklight` | utilities | — | 0.50 | mock client: keyword match |
-| `dwellclick` | utilities | — | 0.50 | mock client: keyword match |
-| `easy-move+resize` | developerTools | — | 0.50 | mock client: keyword match |
-| `eez-studio` | utilities | — | 0.50 | mock client: keyword match |
-| `empoche` | utilities | — | 0.50 | mock client: keyword match |
-| `equibop` | developerTools | — | 0.50 | mock client: keyword match |
-| `equinox` | screensaverWallpaper | — | 0.50 | mock client: keyword match |
-| `eurkey-next` | developerTools | — | 0.50 | mock client: keyword match |
-| `executor` | utilities | — | 0.50 | mock client: keyword match |
-| `exo` | developerTools | — | 0.50 | mock client: keyword match |
-| `extradock` | developerTools | — | 0.50 | mock client: keyword match |
-| `fabric-app` | developerTools | — | 0.50 | mock client: keyword match |
-| `facescreen` | developerTools | — | 0.50 | mock client: keyword match |
-| `factory` | utilities | — | 0.50 | mock client: keyword match |
-| `fidelity-trader+` | developerTools | — | 0.50 | mock client: keyword match |
-| `flow5` | designGraphics | — | 0.50 | mock client: keyword match |
-| `fluidvoice` | utilities | — | 0.50 | mock client: keyword match |
-| `fredm-fuse` | games | — | 0.50 | mock client: keyword match |
-| `general-software-fresh` | utilities | — | 0.50 | mock client: keyword match |
-| `geolibre` | utilities | — | 0.50 | mock client: keyword match |
-| `ghostpepper` | developerTools | — | 0.50 | mock client: keyword match |
-| `ghostvm` | developerTools | — | 0.50 | mock client: keyword match |
-| `gitcomet` | developerTools | — | 0.50 | mock client: keyword match |
-| `github-copilot-app` | developerTools | — | 0.50 | mock client: keyword match |
-| `gnome` | utilities | — | 0.50 | mock client: keyword match |
-| `go2tv` | developerTools | — | 0.50 | mock client: keyword match |
-| `google-gemini` | utilities | ai | 0.50 | mock client: keyword match |
-| `gopher64` | developerTools | — | 0.50 | mock client: keyword match |
-| `gram` | developerTools | — | 0.50 | mock client: keyword match |
-| `greensignal` | utilities | — | 0.50 | mock client: keyword match |
-| `grok-build` | developerTools | — | 0.50 | mock client: keyword match |
-| `groove-omnidialer` | utilities | — | 0.50 | mock client: keyword match |
-| `happ` | utilities | — | 0.50 | mock client: keyword match |
-| `harper-desktop` | utilities | — | 0.50 | mock client: keyword match |
-| `harvest` | utilities | — | 0.50 | mock client: keyword match |
-| `headlamp` | utilities | — | 0.50 | mock client: keyword match |
-| `hive-app` | developerTools | — | 0.50 | mock client: keyword match |
-| `hop` | developerTools | — | 0.50 | mock client: keyword match |
-| `ibm-notifier` | developerTools | — | 0.50 | mock client: keyword match |
-| `icanhazshortcut` | developerTools | — | 0.50 | mock client: keyword match |
-| `idevice-pair` | developerTools | — | 0.50 | mock client: keyword match |
-| `incident-io` | developerTools | — | 0.50 | mock client: keyword match |
-| `input0` | developerTools | — | 0.50 | mock client: keyword match |
-| `intellij-idea-oss` | developerTools | — | 0.50 | mock client: keyword match |
-| `intiface-central` | developerTools | — | 0.50 | mock client: keyword match |
-| `iplay` | utilities | — | 0.50 | mock client: keyword match |
-| `iptvnator` | developerTools | — | 0.50 | mock client: keyword match |
-| `itsytv` | utilities | — | 0.50 | mock client: keyword match |
-| `jetbrains-air` | developerTools | — | 0.50 | mock client: keyword match |
-| `jiba` | audioMusic | — | 0.50 | mock client: keyword match |
-| `kde-connect` | utilities | — | 0.50 | mock client: keyword match |
-| `keyscreen` | videoMedia | — | 0.50 | mock client: keyword match |
-| `kimi` | developerTools | — | 0.50 | mock client: keyword match |
-| `koharu` | utilities | ai | 0.50 | mock client: keyword match |
-| `kotlin-lsp` | developerTools | — | 0.50 | mock client: keyword match |
-| `kstars` | utilities | — | 0.50 | mock client: keyword match |
-| `letos` | utilities | — | 0.50 | mock client: keyword match |
-| `libifd-cyberjack` | developerTools | — | 0.50 | mock client: keyword match |
-| `ltx-desktop` | developerTools | — | 0.50 | mock client: keyword match |
-| `macmd-viewer` | utilities | — | 0.50 | mock client: keyword match |
-| `macmediakeyforwarder` | developerTools | — | 0.50 | mock client: keyword match |
-| `macparakeet` | utilities | — | 0.50 | mock client: keyword match |
-| `macshot` | developerTools | — | 0.50 | mock client: keyword match |
-| `mactools` | developerTools | — | 0.50 | mock client: keyword match |
-| `macusb` | developerTools | — | 0.50 | mock client: keyword match |
-| `maestri` | developerTools | — | 0.50 | mock client: keyword match |
-| `manus` | utilities | — | 0.50 | mock client: keyword match |
-| `masscode` | developerTools | — | 0.50 | mock client: keyword match |
-| `mater` | developerTools | — | 0.50 | mock client: keyword match |
-| `meetily` | designGraphics | — | 0.50 | mock client: keyword match |
-| `meta-quest-remote-desktop` | utilities | — | 0.50 | mock client: keyword match |
-| `miaoyan` | utilities | — | 0.50 | mock client: keyword match |
-| `microsoft-365-copilot` | utilities | — | 0.50 | mock client: keyword match |
-| `microsoft-remote-help` | developerTools | — | 0.50 | mock client: keyword match |
-| `mindmanager` | utilities | — | 0.50 | mock client: keyword match |
-| `mirai` | utilities | — | 0.50 | mock client: keyword match |
-| `mister-plimsoll` | utilities | — | 0.50 | mock client: keyword match |
-| `mkvtoolnix-app` | utilities | — | 0.50 | mock client: keyword match |
-| `mole-app` | utilities | — | 0.50 | mock client: keyword match |
-| `mos` | utilities | — | 0.50 | mock client: keyword match |
-| `mudlet` | utilities | — | 0.50 | mock client: keyword match |
-| `muesli` | utilities | — | 0.50 | mock client: keyword match |
-| `mujoco` | utilities | — | 0.50 | mock client: keyword match |
-| `navigator` | utilities | — | 0.50 | mock client: keyword match |
-| `netxms-console` | utilities | — | 0.50 | mock client: keyword match |
-| `nimbalyst` | developerTools | — | 0.50 | mock client: keyword match |
-| `nostalgiapp` | games | — | 0.50 | mock client: keyword match |
-| `notchi` | developerTools | — | 0.50 | mock client: keyword match |
-| `notion-cli` | utilities | — | 0.50 | mock client: keyword match |
-| `nvidia-nsight-compute` | developerTools | — | 0.50 | mock client: keyword match |
-| `nvidia-sync` | developerTools | — | 0.50 | mock client: keyword match |
-| `ob-xf` | audioMusic | — | 0.50 | mock client: keyword match |
-| `onexrayse` | securityPrivacy | — | 0.50 | mock client: keyword match |
-| `open-design` | developerTools | — | 0.50 | mock client: keyword match |
-| `open-island` | developerTools | — | 0.50 | mock client: keyword match |
-| `open-webui` | developerTools | — | 0.50 | mock client: keyword match |
-| `openchamber` | developerTools | — | 0.50 | mock client: keyword match |
-| `opencpn` | utilities | — | 0.50 | mock client: keyword match |
-| `openhuman` | utilities | ai | 0.50 | mock client: keyword match |
-| `openin` | communication | — | 0.50 | mock client: keyword match |
-| `openlogi` | developerTools | — | 0.50 | mock client: keyword match |
-| `openpencil` | designGraphics | — | 0.50 | mock client: keyword match |
-| `opensc-app` | developerTools | — | 0.50 | mock client: keyword match |
-| `openusage` | developerTools | — | 0.50 | mock client: keyword match |
-| `openwork` | developerTools | — | 0.50 | mock client: keyword match |
-| `orchard` | developerTools | — | 0.50 | mock client: keyword match |
-| `overtone-analyzer` | audioMusic | — | 0.50 | mock client: keyword match |
-| `palmier-pro` | developerTools | — | 0.50 | mock client: keyword match |
-| `pangolin` | developerTools | — | 0.50 | mock client: keyword match |
-| `paper-design` | designGraphics | — | 0.50 | mock client: keyword match |
-| `paranoia-file-text-encryption` | securityPrivacy | — | 0.50 | mock client: keyword match |
-| `paseo` | developerTools | — | 0.50 | mock client: keyword match |
-| `pencil2d` | designGraphics | — | 0.50 | mock client: keyword match |
-| `pgen` | browsers | — | 0.50 | mock client: keyword match |
-| `ping-island` | developerTools | — | 0.50 | mock client: keyword match |
-| `pique` | developerTools | — | 0.50 | mock client: keyword match |
-| `plamo-translate` | utilities | — | 0.50 | mock client: keyword match |
-| `platinum-notes` | audioMusic | — | 0.50 | mock client: keyword match |
-| `pluralplay-flclashx` | developerTools | — | 0.50 | mock client: keyword match |
-| `pocket-bard` | audioMusic | — | 0.50 | mock client: keyword match |
-| `power-monitor` | developerTools | — | 0.50 | mock client: keyword match |
-| `presentify` | utilities | — | 0.50 | mock client: keyword match |
-| `proton-meet` | developerTools | — | 0.50 | mock client: keyword match |
-| `psiphon-conduit` | utilities | — | 0.50 | mock client: keyword match |
-| `puremac` | developerTools | — | 0.50 | mock client: keyword match |
-| `pycharm-oss` | developerTools | — | 0.50 | mock client: keyword match |
-| `qlmarkdown` | developerTools | — | 0.50 | mock client: keyword match |
-| `r-rig-app` | developerTools | — | 0.50 | mock client: keyword match |
-| `radial` | utilities | — | 0.50 | mock client: keyword match |
-| `radix` | utilities | — | 0.50 | mock client: keyword match |
-| `rayon` | designGraphics | — | 0.50 | mock client: keyword match |
-| `rcmd` | utilities | — | 0.50 | mock client: keyword match |
-| `remanager` | developerTools | — | 0.50 | mock client: keyword match |
-| `renameclick` | utilities | — | 0.50 | mock client: keyword match |
-| `revpdf-editor` | utilities | — | 0.50 | mock client: keyword match |
-| `rockxy` | utilities | — | 0.50 | mock client: keyword match |
-| `rowboat` | utilities | — | 0.50 | mock client: keyword match |
-| `runtimeviewer` | developerTools | — | 0.50 | mock client: keyword match |
-| `rustcast` | utilities | — | 0.50 | mock client: keyword match |
-| `screenkite` | utilities | — | 0.50 | mock client: keyword match |
-| `seamly2d` | designGraphics | — | 0.50 | mock client: keyword match |
-| `seekfast` | utilities | — | 0.50 | mock client: keyword match |
-| `server-box` | developerTools | — | 0.50 | mock client: keyword match |
-| `session-manager-plugin` | developerTools | — | 0.50 | mock client: keyword match |
-| `shade` | utilities | — | 0.50 | mock client: keyword match |
-| `sharefile` | developerTools | — | 0.50 | mock client: keyword match |
-| `shichizip` | developerTools | — | 0.50 | mock client: keyword match |
-| `shichizip-zs` | developerTools | — | 0.50 | mock client: keyword match |
-| `silkypix-developer-studio-se` | utilities | — | 0.50 | mock client: keyword match |
-| `slashy` | communication | — | 0.50 | mock client: keyword match |
-| `slicer` | developerTools | — | 0.50 | mock client: keyword match |
-| `smoothcapture` | developerTools | — | 0.50 | mock client: keyword match |
-| `snapzy` | utilities | — | 0.50 | mock client: keyword match |
-| `snippety` | officeTools | — | 0.50 | mock client: keyword match |
-| `sonarqube-cli` | developerTools | — | 0.50 | mock client: keyword match |
-| `spectra-app` | developerTools | — | 0.50 | mock client: keyword match |
-| `speechify-voice-ai` | utilities | ai | 0.50 | mock client: keyword match |
-| `spokenly` | utilities | — | 0.50 | mock client: keyword match |
-| `sshfs-mac` | developerTools | — | 0.50 | mock client: keyword match |
-| `stremio` | developerTools | — | 0.50 | mock client: keyword match |
-| `stremioservice` | videoMedia | — | 0.50 | mock client: keyword match |
-| `subtitle-studio` | videoMedia | — | 0.50 | mock client: keyword match |
-| `supasidebar` | developerTools | — | 0.50 | mock client: keyword match |
-| `supaterm` | developerTools | — | 0.50 | mock client: keyword match |
-| `super` | developerTools | — | 0.50 | mock client: keyword match |
-| `syntax-highlight` | developerTools | — | 0.50 | mock client: keyword match |
-| `t3-code` | developerTools | — | 0.50 | mock client: keyword match |
-| `tablen` | utilities | — | 0.50 | mock client: keyword match |
-| `tablepro` | utilities | — | 0.50 | mock client: keyword match |
-| `tangleguard-cli` | developerTools | ai | 0.50 | mock client: keyword match |
-| `tencent-ugit` | developerTools | — | 0.50 | mock client: keyword match |
-| `terax` | developerTools | — | 0.50 | mock client: keyword match |
-| `tikz-editor` | developerTools | — | 0.50 | mock client: keyword match |
-| `tldraw` | developerTools | — | 0.50 | mock client: keyword match |
-| `todometer` | developerTools | — | 0.50 | mock client: keyword match |
-| `tolaria` | developerTools | — | 0.50 | mock client: keyword match |
-| `transcribex` | utilities | — | 0.50 | mock client: keyword match |
-| `trickster` | utilities | — | 0.50 | mock client: keyword match |
-| `tuna` | utilities | — | 0.50 | mock client: keyword match |
-| `tunarr` | utilities | — | 0.50 | mock client: keyword match |
-| `typewhisper` | utilities | — | 0.50 | mock client: keyword match |
-| `ua-connect` | audioMusic | — | 0.50 | mock client: keyword match |
-| `ulaa` | browsers | — | 0.50 | mock client: keyword match |
-| `unblocked` | developerTools | — | 0.50 | mock client: keyword match |
-| `uniclipboard` | securityPrivacy | — | 0.50 | mock client: keyword match |
-| `unity` | games | — | 0.50 | mock client: keyword match |
-| `unity-ios-support-for-editor` | utilities | — | 0.50 | mock client: keyword match |
-| `unity-webgl-support-for-editor` | utilities | — | 0.50 | mock client: keyword match |
-| `unity-windows-support-for-editor` | utilities | — | 0.50 | mock client: keyword match |
-| `valkey-admin` | utilities | — | 0.50 | mock client: keyword match |
-| `vcmi` | utilities | — | 0.50 | mock client: keyword match |
-| `vibe-island` | developerTools | — | 0.50 | mock client: keyword match |
-| `vibe-notch` | developerTools | — | 0.50 | mock client: keyword match |
-| `vibeproxy` | developerTools | ai | 0.50 | mock client: keyword match |
-| `visual-paradigm-ce` | designGraphics | — | 0.50 | mock client: keyword match |
-| `vmlx` | developerTools | — | 0.50 | mock client: keyword match |
-| `vocevista-video` | developerTools | — | 0.50 | mock client: keyword match |
-| `vocevista-video-pro` | developerTools | — | 0.50 | mock client: keyword match |
-| `voicemod` | utilities | — | 0.50 | mock client: keyword match |
-| `vuze` | utilities | — | 0.50 | mock client: keyword match |
-| `wallspace` | screensaverWallpaper | — | 0.50 | mock client: keyword match |
-| `whatcable` | developerTools | — | 0.50 | mock client: keyword match |
-| `whichspace` | developerTools | — | 0.50 | mock client: keyword match |
-| `worksheet-crafter` | utilities | — | 0.50 | mock client: keyword match |
-| `wowup-cf` | utilities | — | 0.50 | mock client: keyword match |
-| `wox` | developerTools | — | 0.50 | mock client: keyword match |
-| `x-air-edit` | developerTools | — | 0.50 | mock client: keyword match |
-| `xdeck` | developerTools | — | 0.50 | mock client: keyword match |
-| `yakit` | developerTools | — | 0.50 | mock client: keyword match |
-| `yojam` | browsers | — | 0.50 | mock client: keyword match |
-| `zush` | developerTools | — | 0.50 | mock client: keyword match |
+| `8bitdo-firmware-updater` | utilities | games | 0.90 | Firmware updater tool for 8BitDo game controllers, a system-level peripheral utility. |
+| `adrafinil` | utilities | ai, developerTools | 0.80 | A system utility that keeps the Mac awake specifically while AI coding agents run. |
+| `agentsmesh` | productivity | ai, developerTools | 0.65 | AI agent workforce platform for task management and collaboration, powered by AI agents likely aimed at dev/productivity workflows. |
+| `agentsview` | developerTools | ai | 0.75 | Tool for browsing and analyzing AI coding agent sessions, targeted at developers. |
+| `airi` | games | ai | 0.60 | AIRI is an AI companion/VTuber app that can play games like Minecraft and Factorio, blending AI and entertainment.' |
+| `altar-ai` | productivity | ai, communication | 0.70 | AI-powered meeting assistant focused on memory, planning and execution fits productivity with AI trait. |
+| `altersend` | utilities | securityPrivacy | 0.75 | A peer-to-peer encrypted file transfer tool, best fit as a file transfer utility with privacy/security traits. |
+| `amore` | developerTools | utilities | 0.85 | A tool for developers to sign, notarize, and distribute macOS apps. |
+| `annotate` | designGraphics | utilities | 0.75 | A screen annotation tool is primarily a graphics markup utility. |
+| `antigravity-cli` | developerTools | ai | 0.75 | A terminal/CLI interface for Google's Antigravity AI agents, primarily a developer tool with AI capabilities. |
+| `antigravity-ide` | developerTools | ai | 0.90 | An AI-powered coding agent IDE from Google is fundamentally a developer tool with AI as a key trait. |
+| `appgridmac` | utilities | productivity | 0.75 | An app launcher replacing Launchpad is a system utility for launching apps. |
+| `ariax` | utilities | — | 0.90 | AriaX is a download manager built on Aria2 for macOS. |
+| `aside` | browsers | ai | 0.85 | Aside is a web browser with an integrated AI assistant for completing tasks. |
+| `atoll` | utilities | menuBar | 0.75 | Atoll adds a Dynamic Island-like notch utility feature to MacBooks, functioning mainly as a menu bar/notch system utility. |
+| `atomcode` | developerTools | ai | 0.90 | A terminal-based AI coding agent for automating development tasks. |
+| `auto-subs` | videoMedia | ai | 0.85 | On-device subtitle generation tool integrating with video editors like DaVinci Resolve and Premiere. |
+| `autofirma` | productivity | securityPrivacy | 0.75 | AutoFirma is a digital signature editor/validator tool, which falls under productivity's e-signing category. |
+| `backblaze-restore` | cloudStorage | utilities | 0.85 | Backblaze Restore is a client for restoring backups from Backblaze's cloud backup service. |
+| `baoliandeng` | securityPrivacy | utilities | 0.90 | A macOS VPN proxy client built on Mihomo/Clash Meta for network proxying. |
+| `baseline` | utilities | developerTools | 0.70 | An MDM-related zero-touch onboarding automation tool for macOS, essentially a system provisioning utility. |
+| `bettercapture` | videoMedia | utilities | 0.90 | A macOS screen recorder producing video files, similar to QuickTime alternatives. |
+| `bettercmdtab` | utilities | productivity | 0.85 | A system-level app switcher replacement enhancing window management, a core utility function. |
+| `brave-origin` | browsers | securityPrivacy | 0.95 | Brave Origin is a privacy-focused web browser. |
+| `buzz` | audioMusic | ai, productivity | 0.80 | Buzz transcribes and translates audio using OpenAI's Whisper AI model, primarily an audio transcription tool. |
+| `cadran` | screensaverWallpaper | utilities | 0.85 | An animated clock wallpaper/screensaver app for the desktop background. |
+| `caldigit-usb-hub-support-driver` | utilities | — | 0.85 | A hardware driver for CalDigit USB hub supporting device compatibility, a system-level utility. |
+| `calendr` | menuBar | productivity | 0.90 | A menu bar calendar app whose core purpose is providing a calendar widget in the menu bar. |
+| `cavalry` | designGraphics | videoMedia | 0.85 | Cavalry is a motion design and animation tool for creating 2D animations and motion graphics. |
+| `cc-pocket` | developerTools | ai | 0.85 | A remote client for controlling Codex and Claude Code coding agent sessions, targeted at developers. |
+| `cc-switch` | developerTools | ai | 0.85 | A configuration manager for AI coding agents like Claude Code, Codex, and Gemini CLI is a developer tool with AI focus. |
+| `chiri` | productivity | — | 0.90 | A CalDAV task management app is a productivity/task manager tool. |
+| `choragus` | audioMusic | menuBar | 0.85 | A native macOS controller app for Sonos speakers, focused on audio playback control. |
+| `chronoid` | productivity | utilities | 0.85 | Automatic time tracking app for productivity insights and invoicing. |
+| `clarify` | productivity | ai | 0.75 | An AI-native CRM tool for managing sales pipelines, best fitting productivity with AI trait. |
+| `claude-devtools` | developerTools | ai | 0.85 | A developer tool for visualizing and debugging Claude Code sessions, tightly tied to AI coding workflows. |
+| `clearance` | productivity | developerTools | 0.75 | A markdown viewer/editor is a writing/productivity tool with developer-adjacent use case. |
+| `clickshare` | utilities | communication | 0.70 | Client software for wireless screen sharing with Barco conferencing hardware, a utility with communication overlap. |
+| `cmux` | developerTools | ai | 0.90 | Terminal emulator built for developers working with AI coding agents. |
+| `codeexpander` | productivity | utilities | 0.75 | Text expansion and clipboard management tool with screenshot annotation features, fitting productivity with utility overlap. |
+| `connectiq-sdk-manager` | developerTools | — | 0.90 | SDK manager for developing apps on Garmin Connect IQ wearable devices. |
+| `copilot-language-server` | developerTools | ai | 0.90 | A language server tool for developers powered by GitHub Copilot's AI code assistant. |
+| `corelocationcli` | developerTools | utilities | 0.75 | A command-line tool for developers to query CoreLocation data, fitting developer tooling with a utility aspect. |
+| `cotypist` | productivity | ai | 0.85 | System-wide AI-powered autocomplete tool for boosting writing productivity across apps. |
+| `cpuinfo` | menuBar | utilities | 0.90 | A CPU meter that lives in the menu bar, functioning as a system monitoring utility. |
+| `craft-agents` | productivity | ai | 0.85 | AI agent desktop app for connecting data sources and multitasking, fitting productivity with an AI trait. |
+| `ctivo` | videoMedia | utilities | 0.85 | cTiVo downloads and converts TiVo recordings into video files, which is primarily a video media tool. |
+| `datadog-agent` | developerTools | utilities | 0.85 | Datadog Agent is a monitoring/observability tool for developers and system administrators. |
+| `dbeaverteam` | developerTools | — | 0.97 | DBeaver is a universal database SQL client/tool for developers. |
+| `dbvr` | developerTools | — | 0.90 | CLI tool for database operations, a developer/database tool. |
+| `dbx` | developerTools | ai | 0.90 | A lightweight desktop database management tool with a built-in AI assistant. |
+| `dcp-o-matic` | videoMedia | — | 0.90 | A tool for converting video/audio/subtitles into Digital Cinema Package format, a video conversion utility. |
+| `dcp-o-matic-batch-converter` | videoMedia | — | 0.90 | Converts video, audio, and subtitles into Digital Cinema Package format, a video conversion tool. |
+| `dcp-o-matic-combiner` | videoMedia | — | 0.90 | Tool converts video/audio/subtitles into DCP for cinema, a video processing utility. |
+| `dcp-o-matic-disk-writer` | videoMedia | utilities | 0.85 | Converts video/audio/subtitles into Digital Cinema Package format and writes it to disk, a video processing/media tool. |
+| `dcp-o-matic-editor` | videoMedia | — | 0.90 | Tool for converting video/audio/subtitles into Digital Cinema Package format, a video media conversion tool. |
+| `dcp-o-matic-encode-server` | videoMedia | utilities | 0.85 | Converts video/audio/subtitles into DCP format for cinema, a video conversion/encoding tool. |
+| `dcp-o-matic-kdm-creator` | videoMedia | utilities | 0.80 | Tool for converting media into Digital Cinema Package format, a video processing utility. |
+| `dcp-o-matic-player` | videoMedia | — | 0.90 | A player for Digital Cinema Package video files. |
+| `dcp-o-matic-playlist-editor` | videoMedia | — | 0.85 | A tool for converting and editing video/audio into Digital Cinema Package format is a video media utility. |
+| `deadbolt` | securityPrivacy | utilities | 0.90 | A file encryption tool for protecting data falls squarely into security/privacy. |
+| `devin-cli` | developerTools | ai | 0.90 | A CLI coding agent tool for developers with AI-powered cloud integration. |
+| `dfu-blaster-pro` | utilities | — | 0.90 | System-level utility that puts Apple silicon Macs into DFU mode for restoring firmware. |
+| `do-not-disturb` | securityPrivacy | utilities | 0.90 | An Objective-See tool that detects physical access/tampering attacks, fitting security & privacy. |
+| `dockspace` | utilities | productivity | 0.70 | A dock customization tool adding widgets, previews, and animations is a system-level utility with productivity flair. |
+| `dot` | menuBar | productivity | 0.90 | A menu bar calendar app focused on meeting reminders and scheduling. |
+| `dotnet-reactor` | developerTools | securityPrivacy | 0.85 | A .NET code obfuscation and protection tool aimed at developers securing their assemblies. |
+| `doxygen-app` | developerTools | — | 0.95 | Doxygen generates documentation from source code, a core developer tool. |
+| `duo-desktop` | securityPrivacy | utilities | 0.90 | Duo Desktop performs endpoint health checks for Cisco Duo's security/authentication platform. |
+| `dusklight` | games | — | 0.97 | An open-source PC port of the game Twilight Princess based on decompilation. |
+| `dwellclick` | utilities | securityPrivacy | 0.70 | An assistive accessibility utility that automates mouse clicks, fitting the system utilities category. |
+| `easy-move+resize` | utilities | — | 0.90 | A system utility that enables window moving and resizing via modifier key and mouse drag. |
+| `eez-studio` | developerTools | designGraphics | 0.60 | EEZ Studio is a visual tool for GUI development and test & measurement automation, aligning with developer tools with a design component.  .... |
+| `empoche` | productivity | — | 0.75 | Time-tracking with task and project management is a productivity tool. |
+| `equibop` | communication | — | 0.90 | Equibop is a custom Discord client, primarily a chat/communication app. |
+| `equinox` | screensaverWallpaper | — | 0.97 | Equinox creates dynamic wallpapers for macOS, matching the screensaver/wallpaper category exactly. |
+| `eurkey-next` | utilities | — | 0.85 | A keyboard layout input method is a system-level utility for macOS. |
+| `executor` | developerTools | ai | 0.75 | A tool discovery/execution layer for AI agents is primarily a developer integration tool with an AI trait. |
+| `exo` | developerTools | ai | 0.80 | EXO is a local AI inference clustering tool for running LLMs across devices, aimed at developers. |
+| `extradock` | utilities | productivity | 0.75 | A system utility that adds customizable floating docks to macOS, enhancing workflow organization. |
+| `fabric-app` | productivity | ai | 0.85 | Fabric is a note-taking and knowledge management workspace enhanced with AI features. |
+| `facescreen` | videoMedia | communication | 0.75 | Overlays camera feed for video calls, streaming, and recording, which is a video-media utility for communication. |
+| `factory` | developerTools | ai | 0.85 | An AI agent tool for building, testing, and shipping software, aimed at developers. |
+| `fidelity-trader+` | financeCrypto | — | 0.95 | Fidelity Trader+ is an active trading platform for stocks and investments. |
+| `flow5` | scienceEducation | designGraphics | 0.75 | Aerodynamic simulation and design tool used for engineering analysis, fitting scientific/engineering software. |
+| `fluidvoice` | productivity | ai | 0.75 | Offline voice-to-text dictation app with AI enhancement fits productivity tooling with AI trait. |
+| `fredm-fuse` | games | — | 0.90 | Fuse is a ZX Spectrum emulator, classifying it as a games/emulator application. |
+| `general-software-fresh` | productivity | utilities | 0.70 | Fresh manages temporary files, screenshots, downloads, and clipboard items as a productivity aid, akin to a clipboard/file manager utility. |
+| `geolibre` | scienceEducation | utilities | 0.75 | A GIS platform for geospatial data visualization and analysis fits science/education tools. |
+| `ghostpepper` | productivity | ai, securityPrivacy | 0.75 | On-device speech-to-text and meeting transcription tool aimed at productivity, using AI voice models with privacy focus. |
+| `ghostvm` | developerTools | securityPrivacy | 0.80 | Virtualization tool for isolated development and sandboxing on Apple Silicon, primarily aimed at developers. |
+| `gitcomet` | developerTools | — | 0.97 | GitComet is a Git GUI client for version control, a core developer tool. |
+| `github-copilot-app` | developerTools | ai | 0.90 | GitHub Copilot is an AI coding agent desktop app for developers. |
+| `gnome` | menuBar | utilities | 0.85 | A menu bar app for searching and sharing GIFs, primarily defined by its menu bar interface. |
+| `go2tv` | videoMedia | utilities | 0.85 | Casts media files to Smart TVs and Chromecast, a video streaming utility. |
+| `google-gemini` | productivity | ai | 0.90 | Google's native desktop AI assistant client is a productivity/chat tool powered by an LLM. |
+| `gopher64` | games | — | 0.95 | N64 emulator used for playing games. |
+| `gram` | developerTools | — | 0.95 | Gram is a code editor forked from Zed, squarely a developer tool. |
+| `greensignal` | utilities | communication, menuBar | 0.70 | A menu-bar utility that checks camera, mic, speaker, and network readiness before video calls. |
+| `grok-build` | developerTools | ai | 0.90 | A terminal-based coding agent CLI tool for developers, powered by AI. |
+| `groove-omnidialer` | communication | productivity | 0.75 | An outbound sales dialer is primarily a calling/communication tool for sales teams. |
+| `happ` | securityPrivacy | utilities | 0.60 | Happ is a proxy/VPN-like tool for bypassing network restrictions, fitting security/privacy tools. |
+| `harper-desktop` | productivity | developerTools | 0.80 | A grammar-checking writing tool aimed at developers, fitting productivity with a developer-tools angle. |
+| `harvest` | productivity | menuBar | 0.80 | Harvest is a time-tracking productivity app that lives primarily in the menu bar. |
+| `headlamp` | developerTools | utilities | 0.90 | Headlamp is a Kubernetes management UI, a developer/devops tool for cluster administration. |
+| `hive-app` | developerTools | ai | 0.85 | A project/worktree manager for orchestrating AI coding agents, targeted at developers. |
+| `hop` | productivity | officeTools | 0.70 | An open-source document viewer/editor for HWP/HWPX files, similar to a standalone document tool rather than a full office suite. |
+| `ibm-notifier` | utilities | — | 0.70 | A system agent for displaying custom notifications, fitting the utilities category. |
+| `icanhazshortcut` | utilities | menuBar | 0.70 | A simple keyboard shortcut manager for macOS, a system-level utility likely living in the menu bar. |
+| `idevice-pair` | developerTools | utilities | 0.75 | CLI tool for generating iOS device pair records, a developer/device management utility. |
+| `incident-io` | developerTools | productivity | 0.75 | Incident management platform for on-call scheduling and incident response, primarily used by engineering teams. |
+| `input0` | productivity | ai, utilities | 0.75 | A voice-to-text input tool using AI transcription for productivity, with system-level integration. |
+| `intellij-idea-oss` | developerTools | — | 0.98 | IntelliJ IDEA is a well-known Java IDE for software development. |
+| `intiface-central` | utilities | — | 0.50 | A control frontend for hardware devices (sex toys) that doesn't fit cleanly elsewhere, closest to a device control utility. |
+| `iplay` | videoMedia | — | 0.85 | iPlay is a cross-platform multimedia player app. |
+| `iptvnator` | videoMedia | — | 0.95 | IPTVnator is a cross-platform video player for IPTV playlists (m3u/m3u8). |
+| `itsytv` | menuBar | utilities | 0.80 | A menu bar app whose primary purpose is remote control of Apple TV from the menu bar. |
+| `jetbrains-air` | developerTools | ai | 0.90 | An agentic development environment for orchestrating AI coding agents like Codex and Claude. |
+| `jiba` | audioMusic | utilities | 0.85 | A tool that fixes Apple Music metadata localisation, closely tied to music library management. |
+| `kde-connect` | utilities | communication | 0.70 | KDE Connect syncs and connects devices for notifications, file transfer, and clipboard sharing, a system-level utility with communication features. |
+| `keyscreen` | utilities | videoMedia | 0.70 | KeyScreen is a system utility that displays keystrokes on screen, useful for screen recording and tutorials. |
+| `kimi` | productivity | ai, communication | 0.85 | Kimi is an AI chat assistant, similar to other LLM chatbot clients categorized as productivity with AI trait. |
+| `koharu` | designGraphics | ai | 0.70 | A manga translation tool using OCR and inpainting on images, closest to design/graphics with an AI trait. |
+| `kotlin-lsp` | developerTools | — | 0.97 | Kotlin Language Server is a developer tooling component for IDE code intelligence. |
+| `kstars` | scienceEducation | — | 0.97 | KStars is a desktop planetarium/astronomy simulation software. |
+| `letos` | developerTools | utilities | 0.85 | Letos is a SQLite database editor/browser tool aimed at developers. |
+| `libifd-cyberjack` | utilities | securityPrivacy | 0.80 | A hardware driver for smart card readers used for secure authentication, best classed as a system utility with security relevance. |
+| `ltx-desktop` | videoMedia | ai | 0.85 | AI-powered video generation and editing desktop app. |
+| `lumide` | developerTools | ai | 0.90 | Lumide is an AI agent-native code editor/IDE for developers. |
+| `macmd-viewer` | productivity | developerTools | 0.80 | A markdown viewer/reader tool with QuickLook integration fits productivity, with developer tools as a secondary due to its use for AI agent/code output. |
+| `macmediakeyforwarder` | utilities | audioMusic | 0.75 | A small system utility that forwards media keys to music apps, incidental to audio playback. |
+| `macparakeet` | productivity | utilities, ai | 0.75 | Local speech-to-text dictation and meeting transcription tool, AI-powered but productivity-focused. |
+| `macshot` | designGraphics | utilities | 0.70 | Screenshot annotation, OCR, and screen recording tool combining design-related capture/edit features with utility functions. |
+| `mactools` | menuBar | utilities | 0.85 | A collection of native macOS menu bar tools, explicitly menu bar focused. |
+| `macusb` | utilities | — | 0.90 | A tool for creating bootable macOS USB installers is a system-level utility. |
+| `maestri` | productivity | ai, developerTools | 0.75 | An infinite canvas app for orchestrating AI agents, terminals, and notes, blending productivity with AI and dev tooling. |
+| `manus` | productivity | ai | 0.85 | An AI agent app that automates local workflows, fitting productivity with an AI trait. |
+| `masscode` | developerTools | productivity | 0.90 | A code snippet manager and developer workspace tool for organizing and reusing code. |
+| `mater` | menuBar | productivity | 0.90 | A native macOS menubar Pomodoro timer app, primarily menu bar UI with productivity focus. |
+| `meetily` | productivity | ai, communication | 0.85 | AI-powered meeting transcription and note-taking assistant, a productivity tool with strong AI trait. |
+| `meta-quest-remote-desktop` | utilities | — | 0.75 | Remote desktop companion app for Meta Quest headsets is a system-level remote access utility. |
+| `miaoyan` | productivity | — | 0.85 | MiaoYan is a lightweight Markdown note-taking editor, fitting productivity. |
+| `microsoft-365-copilot` | productivity | ai | 0.85 | AI-first productivity assistant app for Microsoft 365, not the full office suite itself. |
+| `microsoft-remote-help` | utilities | communication | 0.75 | Remote Help is a remote-desktop/screen-sharing tool for IT support, which fits the remote desktop utilities bucket. |
+| `mindmanager` | productivity | — | 0.85 | MindManager is a mind mapping and visual work-management tool used for organizing tasks and information. |
+| `mirai` | developerTools | ai | 0.60 | An inference engine for AI models is primarily a developer tool for running AI models, with AI as a strong secondary trait. |
+| `mister-plimsoll` | menuBar | utilities | 0.85 | A menu-bar utility that monitors disk space and notifies when drives get full. |
+| `mkvtoolnix-app` | videoMedia | utilities | 0.95 | MKVToolNix is a GUI toolset for creating and editing Matroska (MKV) video container files. |
+| `mole-app` | utilities | menuBar | 0.90 | A native macOS system cleanup and disk analysis utility with a menu bar HUD feature. |
+| `mos` | utilities | menuBar | 0.90 | A system utility that adjusts mouse scroll behavior, typically running from the menu bar. |
+| `mudlet` | games | — | 0.90 | Mudlet is a MUD (multiplayer text-based game) client for connecting to and playing games. |
+| `muesli` | productivity | ai, audioMusic | 0.75 | Local-first dictation and meeting transcription tool powered by on-device AI speech recognition models. |
+| `mujoco` | scienceEducation | developerTools | 0.85 | MuJoCo is a physics simulation engine used primarily for scientific research and robotics/AI development. |
+| `navigator` | utilities | — | 0.80 | Companion configuration app for a hardware trackpad/trackball device, fitting system utility/peripheral configurator scope. |
+| `netxms-console` | utilities | developerTools | 0.75 | NetXMS is a network and infrastructure monitoring/management console, a system-level utility used by network admins. |
+| `nimbalyst` | developerTools | ai, productivity | 0.80 | A visual workspace for managing AI coding agent sessions (Claude Code, Codex), tasks, and files—primarily a developer tool with AI integration. |
+| `nostalgiapp` | games | utilities | 0.90 | A retro game launcher/frontend for managing and launching classic game collections. |
+| `notchi` | menuBar | developerTools, ai | 0.75 | A notch/menu-bar companion widget that reacts to Claude Code AI activity in real-time. |
+| `notion-cli` | developerTools | productivity | 0.75 | A command-line interface for interacting with Notion is a developer tool tied to a productivity platform. |
+| `nvidia-nsight-compute` | developerTools | — | 0.95 | A CUDA/OptiX profiler and debugger for developers. |
+| `nvidia-sync` | developerTools | utilities | 0.70 | Tool for launching applications/containers on remote systems, akin to a dev/remote-management utility. |
+| `ob-xf` | audioMusic | — | 0.97 | OB-Xf is a virtual analog synthesizer audio plugin from the Surge Synth Team. |
+| `onexrayse` | securityPrivacy | utilities | 0.85 | Xray-core client is a VPN/proxy tool for secure network connections. |
+| `open-design` | designGraphics | ai, developerTools | 0.70 | An AI agent-native design tool for building prototypes and interfaces, combining design and coding agent functionality. |
+| `open-island` | developerTools | ai, menuBar | 0.75 | A companion app for AI coding agents used in terminals, geared toward developers, likely with a menu-bar/dynamic island UI. |
+| `open-webui` | productivity | ai | 0.85 | Open WebUI is a self-hosted interface for interacting with AI/LLM models, similar to a chatbot productivity tool. |
+| `openchamber` | developerTools | ai | 0.90 | An agentic AI coding environment for developers to review diffs and manage coding sessions. |
+| `opencpn` | scienceEducation | utilities | 0.70 | OpenCPN is a marine chart plotter/navigation tool, closest to science/education navigation software with utility aspects. |
+| `openhuman` | productivity | ai | 0.80 | Personal AI assistant app is a productivity tool powered by AI/LLM technology. |
+| `openin` | utilities | menuBar | 0.75 | OpenIn routes links, emails, and files to preferred apps, a system-level utility often accessed from the menu bar. |
+| `openlogi` | utilities | — | 0.85 | A device configurator for Logitech HID++ peripherals, similar to game controller config tools classified as utilities. |
+| `openpencil` | designGraphics | ai | 0.90 | OpenPencil is a design editor compatible with Figma, with built-in AI features. |
+| `opensc-app` | securityPrivacy | utilities | 0.85 | OpenSC provides smart card libraries and middleware for authentication and encryption, a security-focused tool. |
+| `openusage` | menuBar | developerTools, ai | 0.85 | A menu bar app that tracks AI coding tool usage/limits for developer tools like Cursor and Claude Code. |
+| `openwork` | developerTools | ai | 0.75 | Desktop GUI for OpenCode, an AI coding agent tool aimed at developer teams. |
+| `orchard` | developerTools | utilities | 0.85 | GUI for managing Apple's container tooling, a developer-focused container management app. |
+| `overtone-analyzer` | audioMusic | utilities | 0.85 | A real-time voice spectrum analyzer and audio editor is fundamentally an audio analysis tool. |
+| `palmier-pro` | videoMedia | ai | 0.90 | It's a video editor with AI-generation features built into the timeline. |
+| `pangolin` | securityPrivacy | utilities | 0.90 | Identity-aware VPN/zero trust remote access platform is a security/privacy tool. |
+| `paper-design` | designGraphics | — | 0.90 | Paper is a design tool for creating interfaces and prototypes, fitting design & graphics. |
+| `paranoia-file-text-encryption` | securityPrivacy | utilities | 0.90 | An encryption tool for files and text with steganography and post-quantum key exchange is fundamentally a security/privacy application. |
+| `paseo` | developerTools | ai | 0.85 | A self-hosted daemon for running AI coding agents like Claude Code and Codex within a dev environment. |
+| `pencil2d` | designGraphics | videoMedia | 0.80 | Pencil2D is a 2D hand-drawn animation creation tool, blending drawing and animation/video output. |
+| `pgen` | developerTools | ai | 0.95 | pgen is a desktop PostgreSQL database client with an AI-assisted schema browser and SQL editor. |
+| `ping-island` | menuBar | developerTools, ai | 0.85 | A menu bar app showing status for AI coding agent sessions like Claude Code and Codex. |
+| `pique` | utilities | developerTools | 0.80 | A Quick Look plugin for syntax-highlighted file previews is a system-level utility with developer-focused use case. |
+| `plamo-translate` | productivity | ai, scienceEducation | 0.75 | An AI-powered Japanese translation tool, fitting productivity with AI trait and language-related education. |
+| `platinum-notes` | audioMusic | — | 0.90 | Audio enhancement tool for music files used by DJs, part of the Mixed In Key suite. |
+| `pluralplay-flclashx` | securityPrivacy | utilities | 0.80 | A proxy/VPN-like client based on Clash/Mihomo core for network traffic routing. |
+| `pocket-bard` | audioMusic | games | 0.85 | An app providing ambient music and sound effects for tabletop RPGs is primarily an audio tool with a gaming use case. |
+| `power-monitor` | utilities | menuBar | 0.80 | System utility that monitors and reports power/battery status, likely via a menu bar interface. |
+| `presentify` | productivity | designGraphics | 0.70 | Presentify is a screen annotation and presentation tool for highlighting and zooming on-screen content during presentations. |
+| `proton-meet` | communication | securityPrivacy | 0.90 | Proton Meet is a video conferencing app with strong encryption emphasis, so communication is primary with privacy as a secondary trait. |
+| `psiphon-conduit` | securityPrivacy | utilities | 0.75 | Psiphon Conduit is a proxy/censorship-circumvention network tool relating to privacy and internet freedom. |
+| `puremac` | utilities | securityPrivacy | 0.90 | System cleaner/cache manager app, similar to CleanMyMac, fits utilities category. |
+| `pycharm-oss` | developerTools | — | 0.98 | PyCharm OSS is an open-source Python IDE from JetBrains. |
+| `qlmarkdown` | utilities | developerTools | 0.85 | A Quick Look system extension for previewing Markdown files is a system-level utility. |
+| `r-rig-app` | developerTools | scienceEducation | 0.80 | rig manages R language installations, a developer tooling utility for the R programming environment. |
+| `radial` | productivity | utilities | 0.75 | A gesture-based pie menu launcher for triggering apps, scripts, and macros is a productivity/automation tool. |
+| `radix` | utilities | — | 0.95 | Radix is a disk space analyzer, a system-level storage utility. |
+| `rayon` | designGraphics | ai | 0.85 | AI-powered floor plan and interior design drawing tool falls under design/graphics with an AI trait. |
+| `rcmd` | utilities | productivity | 0.85 | An app switcher utility that enhances macOS Command-Tab functionality via a menu-driven productivity feature. |
+| `remanager` | utilities | — | 0.60 | A desktop app for managing device mods on reMarkable tablets fits best as a system/device management utility. |
+| `renameclick` | utilities | ai | 0.80 | Local AI-powered file renaming and organization tool is a system-level file utility with AI trait. |
+| `revpdf-editor` | productivity | — | 0.90 | RevPDF is a standalone PDF editor for annotation and editing, fitting productivity per the PDF tool guidance. |
+| `rockxy` | developerTools | securityPrivacy | 0.90 | A native macOS HTTP/HTTPS debugging proxy for inspecting and intercepting network traffic is a developer tool. |
+| `rowboat` | productivity | ai | 0.80 | An AI-powered desktop assistant that manages tasks and knowledge, fitting productivity with an AI trait. |
+| `runtimeviewer` | developerTools | — | 0.90 | A reverse-engineering tool for inspecting Objective-C and Swift runtime interfaces is a developer utility. |
+| `rustcast` | productivity | utilities | 0.60 | Rustcast is an application and utility launcher, similar to productivity launcher tools like Alfred/Raycast.' |
+| `screenkite` | videoMedia | utilities | 0.90 | ScreenKite is a native macOS screen recorder and editor, fitting video/media tools. |
+| `seamly2d` | designGraphics | — | 0.75 | Seamly2D is pattern-making/fashion design software, fitting design & graphics tools. |
+| `seekfast` | utilities | productivity | 0.70 | A file/document text search tool is a system utility with productivity overlap. |
+| `server-box` | developerTools | utilities | 0.75 | SSH/SFTP and server monitoring tool with container management, aligning with developer tools and system utilities. |
+| `session-manager-plugin` | developerTools | utilities | 0.90 | AWS CLI plugin for managing remote sessions, a developer/cloud command-line tool. |
+| `shade` | cloudStorage | ai, videoMedia | 0.60 | AI-powered media storage and asset management platform functions as a cloud storage system for media files with AI search features. |
+| `sharefile` | cloudStorage | securityPrivacy | 0.85 | ShareFile is a cloud storage and file sharing client service. |
+| `shichizip` | utilities | — | 0.90 | A 7-Zip archive/compression GUI utility for macOS. |
+| `shichizip-zs` | utilities | — | 0.90 | A file compression/archive tool (7-Zip derivative) is a system-level utility. |
+| `silkypix-developer-studio-se` | designGraphics | utilities | 0.90 | RAW image development/editing software for photographers is a photo editing tool.' |
+| `slashy` | communication | — | 0.90 | Slashy is a dedicated email client for Gmail, fitting the communication category. |
+| `slicer` | scienceEducation | designGraphics | 0.85 | 3D Slicer is a medical/scientific image analysis and visualization platform used in research and education. |
+| `smoothcapture` | videoMedia | designGraphics | 0.90 | Screen recorder and video editor for creating polished demo videos with cursor effects and device frames. |
+| `snapzy` | designGraphics | menuBar, videoMedia | 0.75 | Screenshot capture, annotation and editing tool operating from the menu bar, with screen recording capability. |
+| `snippety` | productivity | utilities | 0.90 | Snippety is a text expander and snippet manager, a productivity tool for automating typing. |
+| `sonarqube-cli` | developerTools | securityPrivacy | 0.90 | A CLI tool for code quality and security scanning integrated into developer workflows and terminal usage. |
+| `spectra-app` | developerTools | ai, productivity | 0.75 | A spec/document management desktop app for spec-driven development workflows with AI assistance, targeted at developers. |
+| `speechify-voice-ai` | productivity | ai, audioMusic | 0.80 | Speechify is an AI-powered text-to-speech reading assistant, primarily a productivity tool with audio and AI traits. |
+| `spokenly` | productivity | ai | 0.85 | AI-powered dictation and transcription app for text productivity, using local Whisper models. |
+| `sshfs-mac` | utilities | developerTools | 0.75 | SSHFS is a filesystem client for mounting remote SSH servers, fitting system-level utilities with developer/SSH overlap. |
+| `stremio` | videoMedia | — | 0.95 | Stremio is a media center app for streaming videos, movies and TV series. |
+| `stremioservice` | videoMedia | utilities | 0.85 | Stremio Service is a companion background service enabling media streaming/playback for Stremio Web. |
+| `subtitle-studio` | videoMedia | ai | 0.90 | An offline AI-powered subtitle generator for video content. |
+| `supasidebar` | productivity | utilities | 0.70 | A sidebar utility for organizing links, files, and folders across apps, best fitting productivity with a utilities trait. |
+| `supaterm` | developerTools | ai | 0.85 | A terminal emulator with agent automation features is a developer tool with AI trait. |
+| `super` | developerTools | — | 0.85 | SuperDB is an analytics database tool, fitting developer tools/database category. |
+| `syntax-highlight` | utilities | developerTools | 0.80 | A Quick Look extension for previewing source code files is a system utility with developer relevance. |
+| `t3-code` | developerTools | ai | 0.85 | A GUI for AI-powered code agents is primarily a developer tool with AI as a key trait. |
+| `tablen` | developerTools | — | 0.95 | A native macOS SQL/database client for developers. |
+| `tablepro` | developerTools | — | 0.97 | TablePro is a native database client for managing multiple database types, a core developer tool. |
+| `tangleguard-cli` | developerTools | ai | 0.75 | A CLI tool for codebase architecture analysis aimed at developers, with LLM context integration. |
+| `tencent-ugit` | developerTools | — | 0.95 | UGit is a Git GUI client, a developer version-control tool. |
+| `terax` | developerTools | ai | 0.90 | An AI-native terminal and code editor workspace for developers. |
+| `tikz-editor` | designGraphics | developerTools | 0.75 | WYSIWYG editor for creating TikZ/LaTeX diagrams, blending graphic editing with developer/document tooling. |
+| `tldraw` | designGraphics | productivity | 0.80 | tldraw is a whiteboard/drawing tool for creating diagrams and sketches from local .tldr files. |
+| `todometer` | productivity | — | 0.90 | A simple to-do list app focused on task management. |
+| `tolaria` | productivity | ai | 0.85 | Markdown-based knowledge/note management tool with AI integration features. |
+| `transcribex` | productivity | ai, audioMusic | 0.75 | A local AI-powered transcription tool that boosts productivity, with AI and audio processing as secondary traits. |
+| `trickster` | utilities | productivity | 0.75 | A menu/keyboard-shortcut utility for quickly accessing recently changed files, functioning as a system productivity utility. |
+| `tuna` | productivity | utilities | 0.80 | An application launcher for macOS that boosts productivity by quick app access. |
+| `tunarr` | videoMedia | utilities | 0.85 | Tunarr creates live TV channels from media libraries like Plex/Jellyfin/Emby, a video media streaming tool. |
+| `typewhisper` | productivity | ai | 0.75 | Speech-to-text and AI text processing tool aimed at boosting productivity, powered by AI. |
+| `ua-connect` | audioMusic | utilities | 0.90 | Device manager/installer for Universal Audio's music production hardware/software. |
+| `ulaa` | browsers | securityPrivacy | 0.95 | Ulaa is a web browser focused on privacy and tracking protection. |
+| `unblocked` | developerTools | ai | 0.85 | AI context engine for coding agents targeting developer collaboration and code generation. |
+| `uniclipboard` | productivity | securityPrivacy | 0.85 | A clipboard manager/sync tool fits productivity, with encryption as a notable trait. |
+| `unity` | developerTools | games | 0.90 | Unity is a game engine/development platform used to build games and apps. |
+| `unity-ios-support-for-editor` | developerTools | games | 0.80 | Unity iOS build support is a development toolchain component for the Unity game engine. |
+| `unity-webgl-support-for-editor` | developerTools | games | 0.85 | Unity WebGL build support is a game engine development tool add-on. |
+| `unity-windows-support-for-editor` | developerTools | games | 0.85 | Build support module for Unity, a game engine and development tool. |
+| `valkey-admin` | developerTools | utilities | 0.90 | A database administration/monitoring tool for Valkey (Redis-like) clusters, targeted at developers. |
+| `vcmi` | games | — | 0.97 | VCMI is an open-source game engine reimplementation for Heroes of Might & Magic III. |
+| `vibe-island` | menuBar | developerTools, ai | 0.75 | A notch/menu-bar panel utility that monitors AI coding agents like Claude Code and Cursor. |
+| `vibe-notch` | menuBar | developerTools, ai | 0.75 | A menu bar/notch UI providing session notifications for Claude Code CLI, tying it to developer tools and AI. |
+| `vibeproxy` | developerTools | menuBar, ai | 0.75 | A menu bar utility that bridges AI subscriptions to coding tools, primarily targeting developers. |
+| `visual-paradigm-ce` | developerTools | designGraphics | 0.75 | A UML/BPMN modeling platform used for software design and architecture is primarily a developer tool. |
+| `vmlx` | productivity | ai, developerTools | 0.80 | An on-device AI app for chat, coding, and image generation is best classified as an AI-driven productivity tool. |
+| `vocevista-video` | scienceEducation | audioMusic | 0.70 | A voice spectrum/vowel resonance analyzer is a scientific analysis tool centered on audio, best fit as science/education with audio secondary. |
+| `vocevista-video-pro` | audioMusic | scienceEducation | 0.75 | A voice spectrum and vibrato analysis tool for vocal/audio study, blending audio analysis with scientific measurement. |
+| `voicemod` | audioMusic | utilities | 0.85 | Voicemod is a real-time voice changer and soundboard app, primarily an audio manipulation tool. |
+| `vuze` | utilities | — | 0.95 | Vuze is a BitTorrent download client, fitting the utilities category for download/torrent tools. |
+| `wallspace` | screensaverWallpaper | — | 0.97 | Live wallpaper app for Mac providing dynamic desktop backgrounds. |
+| `whatcable` | menuBar | utilities | 0.85 | A menu bar app dedicated to diagnosing USB-C cable capabilities, a system utility function. |
+| `whichspace` | menuBar | utilities | 0.95 | A menu bar utility that shows and switches macOS Spaces. |
+| `worksheet-crafter` | scienceEducation | productivity | 0.85 | A tool for teachers to create lesson materials and worksheets, fitting education software. |
+| `wowup-cf` | utilities | games | 0.75 | An addon manager for World of Warcraft is a utility tool tied to gaming but not a game itself. |
+| `wox` | productivity | utilities | 0.80 | Wox is an application launcher, similar to Alfred/Spotlight alternatives, best fit as a productivity tool with utility overlap. |
+| `x-air-edit` | audioMusic | utilities | 0.85 | Remote control app for Behringer X AIR digital mixers, an audio production hardware tool. |
+| `xdeck` | communication | — | 0.90 | XDeck is a Twitter/X social media client, a communication/social app. |
+| `yakit` | securityPrivacy | developerTools | 0.85 | Yakit is a cybersecurity testing platform for penetration testing and vulnerability scanning. |
+| `yojam` | utilities | menuBar, browsers | 0.80 | A menu bar utility that routes links to browsers/apps based on rules, primarily a system-level utility. |
+| `zush` | utilities | ai | 0.85 | A file renaming and organizing tool that uses AI, fitting system-level file utilities with an AI trait. |
 
 ## Deprecated/disabled (pruned)
 - `after-dark-classic`

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -467,6 +467,13 @@
     "error": "The read operation timed out"
   },
   {
+    "token": "adrafinil",
+    "homepage": "https://kagerou.glass/adrafinil/",
+    "title": "Adrafinil — it sleeps when there's nothing left to do",
+    "meta_desc": "Adrafinil keeps your Mac awake only while AI agents are working, lid fully closed, and sleeps the instant the last session ends. macOS · free · open source.",
+    "og_desc": "Close the laptop. The agents keep working: locked, pocketable, awake only underneath. The Mac sleeps the moment the last session ends. macOS · free · open source."
+  },
+  {
     "token": "adrive",
     "homepage": "https://www.aliyundrive.com/",
     "title": "阿里云盘 - 备份无忧 整理有序·阿里巴巴集团出品",
@@ -31351,6 +31358,13 @@
     "title": "Objective-See: LuLu",
     "meta_desc": "",
     "og_desc": ""
+  },
+  {
+    "token": "lumide",
+    "homepage": "https://lumide.dev/",
+    "title": "Lumide | The Agent-Native IDE",
+    "meta_desc": "Lumide is a high-performance, lightweight code editor built for the agentic age. Host autonomous agents natively via the Agent Client Protocol with zero Electron overhead.",
+    "og_desc": "Lumide is a high-performance, lightweight code editor built for the agentic age. Host autonomous agents natively via the Agent Client Protocol with zero Electron overhead."
   },
   {
     "token": "luminance-hdr",


### PR DESCRIPTION
First real classification run (Claude Sonnet 5, structured outputs, ~3 min, ~$0.50).

## Results

- **281/281 new casks classified, zero failures** (structured outputs did their job)
- **13 renames migrated** via `old_tokens` — no LLM calls (`windsurf` → `devin-desktop`, etc.)
- **28 deprecated/disabled pruned**
- Catalog: 3,534 → **3,786 casks**, `generatedDate: 2026-07-06`

## Distribution of the 281

developerTools 73 · utilities 51 · productivity 50 · videoMedia 25 · menuBar 15 · designGraphics 14 · securityPrivacy 12 · audioMusic 11 · scienceEducation 8 · games 7 · communication 5 · browsers 3 · cloudStorage 3 · screensaverWallpaper 3 · financeCrypto 1 — and **0 in `other`**. 80 casks carry the `ai` trait.

## Review focus

Only **9 items below 0.7 confidence** — see the "New classifications" table in `data/classification_report.md` (sortable by confidence). The lowest: `intiface-central` (0.50 → utilities), `airi` (0.60 → games), `eez-studio` (0.60 → developerTools).

## After merge

Merging triggers `release.yml` → new `data-2026.07.xx` release with a newer `generatedDate`, which every installed CaskHub picks up on next launch via `refreshFromRemote()`. Remember to run `Scripts/sync_bundled_categories.sh` in CaskHub before the next app release.