### PR TITLE
feat: Resume icon report from rolling branch at run start

### DIFF
--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -29,6 +29,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The rolling report PR may not be merged between runs; without this,
+      # a run would start from master's stale report and the report PR's
+      # force-push would clobber the previous run's outcomes (happened
+      # between the batch-1 review rerun and batch 2).
+      - name: Resume report state from rolling branch
+        run: |
+          if git fetch origin icon-extraction-report 2>/dev/null; then
+            git checkout FETCH_HEAD -- data/icon_report.json || true
+            echo "resumed report from rolling branch"
+          fi
+
       - name: Extract and publish icons
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fixes the report-clobber race found between the review rerun and batch 2: consecutive runs start from master's report, so an unmerged rolling PR's outcomes get force-pushed away. Now each run restores `data/icon_report.json` from the rolling branch before extracting. (Icons were never at risk — the icons branch is append-only.) The clobbered state itself was reconstructed and merged in #7.