### PR TITLE
chore: Review-queue audit: park microsoft-office, clear 4 verified icons

### DIFF
--- a/data/icon_report.json
+++ b/data/icon_report.json
@@ -185,12 +185,6 @@
     "attempts": 0,
     "updated": "2026-07-06"
   },
-  "google-japanese-ime": {
-    "status": "review",
-    "reason": "non-exact .app selection: shallowest",
-    "attempts": 0,
-    "updated": "2026-07-06"
-  },
   "gpg-suite": {
     "status": "no_icon",
     "reason": "only installer/updater apps in artifact",
@@ -221,23 +215,11 @@
     "attempts": 0,
     "updated": "2026-07-06"
   },
-  "mactex": {
-    "status": "review",
-    "reason": "non-exact .app selection: shallowest",
-    "attempts": 0,
-    "updated": "2026-07-06"
-  },
-  "mactex-no-gui": {
-    "status": "review",
-    "reason": "non-exact .app selection: shallowest",
-    "attempts": 0,
-    "updated": "2026-07-06"
-  },
   "microsoft-office": {
-    "status": "review",
-    "reason": "non-exact .app selection: shallowest",
+    "status": "no_icon",
+    "reason": "multi-app suite; shallowest picked the Defender shim (manual audit 2026-07-07)",
     "attempts": 0,
-    "updated": "2026-07-06"
+    "updated": "2026-07-07"
   },
   "mysql-shell": {
     "status": "failed",
@@ -302,12 +284,6 @@
   "quarto": {
     "status": "no_icon",
     "reason": "no .app found in expanded artifact",
-    "attempts": 0,
-    "updated": "2026-07-06"
-  },
-  "r-app": {
-    "status": "review",
-    "reason": "non-exact .app selection: single",
     "attempts": 0,
     "updated": "2026-07-06"
   },


### PR DESCRIPTION
Visual audit of the 5-cask review queue: google-japanese-ime ✓, r-app ✓, mactex/mactex-no-gui ✓ (TeXShop icon — the distribution's flagship editor, representative), **microsoft-office ✗** — it shipped the Microsoft Defender shim icon (shallowest pick in the suite installer payload). Since a full suite has no canonical icon, it's parked `no_icon` and the PNG is deleted from the icons branch; the pinned report entry stops future batches from re-attempting it.