### PR TITLE
feat: Skip @-variants and font-* in icon batch selection

### DIFF
--- a/scripts/extract_icons.py
+++ b/scripts/extract_icons.py
@@ -465,6 +465,8 @@ def load_install_counts() -> dict[str, int]:
 
 
 def select_candidates(api_casks: list[dict], report: dict, limit: int) -> list[dict]:
+    from classify_new_casks import is_main_cask  # shared "what the app shows" filter
+
     done = published_tokens()
     parked = {
         t for t, e in report.items()
@@ -473,7 +475,12 @@ def select_candidates(api_casks: list[dict], report: dict, limit: int) -> list[d
     }
     candidates = [
         c for c in api_casks
-        if c["token"] not in done and c["token"] not in parked and eligibility(c) is None
+        # is_main_cask: skip @-version variants and font-* — the app filters
+        # them out, so their icons would never be requested (--tokens still
+        # bypasses this for manual runs)
+        if is_main_cask(c)
+        and c["token"] not in done and c["token"] not in parked
+        and eligibility(c) is None
     ]
     counts = load_install_counts()
     candidates.sort(key=lambda c: counts.get(c["token"], 0), reverse=True)

--- a/tests/test_extract_icons.py
+++ b/tests/test_extract_icons.py
@@ -156,3 +156,15 @@ def test_find_app_single_ignores_installer_sibling(tmp_path):
     target = _mk_app(tmp_path, "RealThing.app")
     app, sel = find_app(tmp_path, [], token="unrelated-token")
     assert app == target and sel == "single"
+
+
+# --- selection skips non-main casks (shared filter with the classifier) -------
+
+from classify_new_casks import is_main_cask  # noqa: E402
+
+
+def test_is_main_cask_shared_filter():
+    assert is_main_cask({"token": "obsidian"})
+    assert not is_main_cask({"token": "1password@beta"})
+    assert not is_main_cask({"token": "font-fira-code"})
+    assert not is_main_cask({"token": "old-tool", "deprecated": True})


### PR DESCRIPTION
The app filters non-main casks out of every view, so their icons are never requested — extracting them burns batch slots and bandwidth. Selection now reuses `classify_new_casks.is_main_cask` (one shared definition of "what the app shows"). Already-published variant PNGs stay as harmless orphans. `--tokens` bypasses the filter for manual runs. 34/34 tests.