### PR TITLE
feat: Phase 4: dirty-token report merge + daily icon cron

### DIFF
--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -1,9 +1,9 @@
 name: Extract icons
 
-# Rollout (see docs/superpowers/specs/2026-07-05-icon-extraction-design.md):
-# manual dispatch only until the backfill completes, then enable the cron.
+# Phase 4 (backfill complete 2026-07-07): daily cron for new casks.
 # All state (PNGs + icon_report.json) lives on the icons branch — the script
-# is the single writer; there is no report on master and no rolling PR.
+# is the single writer and merges report edits by dirty-token, so manual
+# audits committed mid-run survive.
 on:
   workflow_dispatch:
     inputs:
@@ -13,8 +13,10 @@ on:
       tokens:
         description: "Specific tokens, space-separated (overrides limit)"
         default: ""
-  # schedule:
-  #   - cron: "0 16 * * *"   # enable after backfill (rollout phase 4)
+  schedule:
+    # 16:00 UTC — after the 14:00 classification cron; a new cask usually
+    # gets its category and its icon on the same day.
+    - cron: "0 16 * * *"
 
 permissions:
   contents: write

--- a/scripts/extract_icons.py
+++ b/scripts/extract_icons.py
@@ -395,10 +395,15 @@ def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
     return run(["git", "-C", str(cwd), *args])
 
 
-def publish_batch(pngs: dict[str, Path], report: dict[str, dict]) -> None:
+def publish_batch(pngs: dict[str, Path], report: dict[str, dict],
+                  dirty: set[str]) -> None:
     """Commit a batch of icons AND the report to the icons branch via a
-    throwaway worktree — icons and their state always land in the same push
-    (single writer, single home; report-only flushes are fine)."""
+    throwaway worktree — icons and their state always land in the same push.
+
+    The report is MERGED, not overwritten: the branch's current copy is the
+    base and only `dirty` tokens (touched by this run) are overlaid. A batch
+    holds its report in memory for an hour+; blind writes clobbered a manual
+    audit committed mid-run (third report race, 2026-07-07)."""
     wt = Path(tempfile.mkdtemp(prefix="icons-wt-"))
     wt_added = False
     try:
@@ -410,7 +415,16 @@ def publish_batch(pngs: dict[str, Path], report: dict[str, dict]) -> None:
         wt_added = True
         for token, png in pngs.items():
             shutil.copyfile(png, wt / f"{token}.png")
-        (wt / REPORT_FILE).write_text(report_json(report))
+        base_file = wt / REPORT_FILE
+        merged: dict[str, dict] = (
+            json.loads(base_file.read_text()) if base_file.exists() else {}
+        )
+        for token in dirty:
+            if token in report:
+                merged[token] = report[token]
+            else:
+                merged.pop(token, None)  # cleared by this run (success)
+        base_file.write_text(report_json(merged))
         _git(wt, "add", "-A")
         if _git(wt, "diff", "--cached", "--quiet").returncode == 0:
             return  # everything already on the branch
@@ -526,9 +540,11 @@ def main(argv: list[str] | None = None) -> int:
     ok = 0
     outcomes: list[tuple[str, str, str]] = []
     pending: dict[str, Path] = {}
+    dirty: set[str] = set()  # tokens whose report entry this run may change
     start = time.time()
     for i, cask in enumerate(batch, 1):
         token = cask["token"]
+        dirty.add(token)
         try:
             status, detail = extract_one(cask, args.output_dir)
             if status == "ok":
@@ -541,7 +557,7 @@ def main(argv: list[str] | None = None) -> int:
                 if args.publish:
                     pending[token] = args.output_dir / f"{token}.png"
                     if len(pending) >= FLUSH_EVERY:
-                        publish_batch(pending, report)
+                        publish_batch(pending, report, dirty)
                         pending.clear()
             else:
                 record(report, token, status, detail)
@@ -557,7 +573,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.publish:
         # Always flush at the end — persists report-only outcomes (failures,
         # parks) even when no new icons were extracted.
-        publish_batch(pending, report)
+        publish_batch(pending, report, dirty)
     else:
         print("(local run — report changes not persisted; use --publish)")
 


### PR DESCRIPTION
## Report race, third variant, structural fix

Batch 13 was already running when the batch-11/12 audit was committed to the icons branch; its final flush wrote its hour-old in-memory report and erased the audit (PNG deletions survived — file ops are append-only; only report entries regressed). Single-writer fixed *where* state lives; this fixes *concurrent writes within the one home*: `publish_batch` now uses the branch's current report as base and overlays only the tokens this run actually touched (`dirty` set). A batch can no longer erase entries it never looked at.

Operationally this also means: **auditing while a batch runs is now safe.**

## Phase 4

Backfill complete — **3,285 icons, 85.3% of main casks** (remainder honestly parked with reasons or in retry). Daily cron enabled at 16:00 UTC, after the 14:00 classification cron, so a new cask typically gets its category and icon the same day. 34/34 tests.