### PR TITLE
fix: Move crons off peak minutes

### DIFF
--- a/.github/workflows/classify-new-casks.yml
+++ b/.github/workflows/classify-new-casks.yml
@@ -2,9 +2,9 @@ name: Classify new casks
 
 on:
   schedule:
-    # 14:00 UTC daily — Homebrew cask updates land throughout the day,
+    # 13:17 UTC daily (off-peak minute — on-the-hour slots run hours late),
     # so afternoon UTC catches most of them in one run.
-    - cron: "0 14 * * *"
+    - cron: "17 13 * * *"
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -14,7 +14,7 @@ on:
         description: "Specific tokens, space-separated (overrides limit)"
         default: ""
   schedule:
-    # 16:00 UTC — after the 14:00 classification cron; a new cask usually
+    # 15:43 UTC — after the 13:17 classification cron; a new cask usually
     # gets its category and its icon on the same day.
     - cron: "0 16 * * *"
 


### PR DESCRIPTION
Evidence from testing the pipeline: the 14:00 UTC cron fired 2.9h late yesterday and hadn't fired at all by 15:26 today — on-the-hour slots are GitHub's most congested and get deprioritized. Moved to off-peak minutes (classification 13:17 UTC, icons 15:43 UTC), same ordering.