### PR TITLE
fix: Move icon cron to 15:43 UTC

### DIFF
--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -16,7 +16,7 @@ on:
   schedule:
     # 15:43 UTC — after the 13:17 classification cron; a new cask usually
     # gets its category and its icon on the same day.
-    - cron: "0 16 * * *"
+    - cron: "43 15 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
Completes #14 — the icons workflow's cron expression didn't get updated with its comment (sed pattern mismatch). Now matches: 15:43 UTC, after the 13:17 classification cron.