### PR TITLE
chore: Curated icon additions + CLI-tile assignments (manual artifact session)

### DIFF
--- a/data/curated_icons.json
+++ b/data/curated_icons.json
@@ -21,6 +21,7 @@
   "miniconda": "https://github.com/conda.png?size=256",
   "miniforge": "https://github.com/conda-forge.png?size=256",
   "mono-mdk": "https://github.com/mono.png?size=256",
+  "mysql-shell": "https://github.com/mysql.png?size=256",
   "opensc-app": "https://github.com/OpenSC.png?size=256",
   "openzfs": "https://github.com/openzfs.png?size=256",
   "oracle-jdk": "https://github.com/oracle.png?size=256",


### PR DESCRIPTION
Accumulated curation session on top of the merged extractor fixes:

- **mysql-shell** curated (pkg ships CLI only; Oracle CDN blocks scripts)
- **CLI tiles** (rendered from CaskHub's design system, published as icons): ibm-cloud-cli, session-manager-plugin, diskspace — matching desktoppr/nordic-nrf/segger-jlink/corelocationcli published directly to the icons branch
- **Curated additions**: chatty, chef-workstation, avast-security, ibkr, kimi, tuxera-ntfs, microsoft-office, gog-galaxy, opensc-app, mono-mdk; zulufx/orka-vm-tools/sshfs-mac reuse family icons
- All icons eye-verified; provenance recorded per token in icon_report.json on the icons branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)