### PR TITLE
fix: default LIMIT for scheduled extract-icons runs

### DIFF
--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TOKENS: ${{ inputs.tokens }}
-          LIMIT: ${{ inputs.limit }}
+          LIMIT: ${{ inputs.limit || '300' }}
         run: |
           if [ -n "$TOKENS" ]; then
             # word-splitting intended: TOKENS is space-separated; the script


### PR DESCRIPTION
## Problem

The daily scheduled run of the **Extract icons** workflow fails immediately ([run 29037360076](https://github.com/alielsokary/CaskKit/actions/runs/29037360076)):

```
extract_icons.py: error: argument --limit: invalid int value: ''
```

`inputs.limit` is only populated on `workflow_dispatch` — input defaults are not applied to `schedule` triggers, so cron runs execute `--limit ""` and exit with code 2 before doing any work.

## Fix

Fall back to the dispatch default in the expression:

```yaml
LIMIT: ${{ inputs.limit || '300' }}
```

## Verification

- YAML validated locally.
- Manual dispatch path is unchanged; the next 15:43 UTC cron run should now process casks instead of failing at argparse.