### PR TITLE
enhancement: caskflow-v release tag scheme with cask count in notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,37 @@ jobs:
           echo "tag=caskflow-v$d" >> "$GITHUB_OUTPUT"
           echo "date=$d" >> "$GITHUB_OUTPUT"
 
-      - name: Read release metadata
-        id: meta
+      - name: Compose release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo "count=$(jq -r .totalCasks categories.json)" >> "$GITHUB_OUTPUT"
-          echo "generated=$(jq -r .generatedDate categories.json)" >> "$GITHUB_OUTPUT"
+          count=$(jq -r .totalCasks categories.json)
+          generated=$(jq -r .generatedDate categories.json)
+          {
+            echo "Daily classification update — **${count} casks**, generated ${generated}."
+
+            pr=$(gh api "repos/$REPO/commits/${{ github.sha }}/pulls" --jq '.[0].number' || true)
+            if [ -n "$pr" ]; then
+              echo ""
+              echo "Changes: #${pr}"
+            fi
+
+            # Diff against the previous release (still "latest" at this point)
+            if curl -fsSL "https://github.com/$REPO/releases/latest/download/categories.json" -o /tmp/prev.json; then
+              jq -r --slurpfile prev /tmp/prev.json \
+                '(.tokenToCategory | keys) - ($prev[0].tokenToCategory | keys) | .[]' \
+                categories.json > /tmp/new_tokens.txt
+              n=$(grep -c . /tmp/new_tokens.txt || true)
+              if [ "$n" -gt 0 ]; then
+                echo ""
+                echo "**${n} new cask(s):**"
+                head -20 /tmp/new_tokens.txt | sed 's/.*/- `&`/'
+                if [ "$n" -gt 20 ]; then
+                  echo "- …and $((n - 20)) more"
+                fi
+              fi
+            fi
+          } > /tmp/release_notes.md
 
       - name: Mine cask added dates
         run: python3 scripts/mine_added_dates.py
@@ -39,14 +65,7 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: "CaskFlow-${{ steps.tag.outputs.date }}"
-          body: |
-            Daily classification update — **${{ steps.meta.outputs.count }} casks**, generated ${{ steps.meta.outputs.generated }}.
-
-            Stable asset URLs (always point to the most recent release):
-            https://github.com/${{ env.REPO }}/releases/latest/download/categories.json
-            https://github.com/${{ env.REPO }}/releases/latest/download/added_dates.json
-
-            See the merged PR for the diff.
+          body_path: /tmp/release_notes.md
           files: |
             categories.json
             added_dates.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,16 @@ jobs:
 
       - name: Compute release tag
         id: tag
-        run: echo "tag=data-$(date -u +%Y.%m.%d)" >> "$GITHUB_OUTPUT"
+        run: |
+          d=$(date -u +%Y.%m.%d)
+          echo "tag=caskflow-v$d" >> "$GITHUB_OUTPUT"
+          echo "date=$d" >> "$GITHUB_OUTPUT"
+
+      - name: Read release metadata
+        id: meta
+        run: |
+          echo "count=$(jq -r .totalCasks categories.json)" >> "$GITHUB_OUTPUT"
+          echo "generated=$(jq -r .generatedDate categories.json)" >> "$GITHUB_OUTPUT"
 
       - name: Mine cask added dates
         run: python3 scripts/mine_added_dates.py
@@ -29,9 +38,9 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          name: "Categories ${{ steps.tag.outputs.tag }}"
+          name: "CaskFlow-${{ steps.tag.outputs.date }}"
           body: |
-            Daily classification update.
+            Daily classification update — **${{ steps.meta.outputs.count }} casks**, generated ${{ steps.meta.outputs.generated }}.
 
             Stable asset URLs (always point to the most recent release):
             https://github.com/${{ env.REPO }}/releases/latest/download/categories.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,18 +42,20 @@ jobs:
 
             # Diff against the previous release (still "latest" at this point)
             if curl -fsSL "https://github.com/$REPO/releases/latest/download/categories.json" -o /tmp/prev.json; then
-              jq -r --slurpfile prev /tmp/prev.json \
-                '(.tokenToCategory | keys) - ($prev[0].tokenToCategory | keys) | .[]' \
-                categories.json > /tmp/new_tokens.txt
-              n=$(grep -c . /tmp/new_tokens.txt || true)
-              if [ "$n" -gt 0 ]; then
-                echo ""
-                echo "**${n} new cask(s):**"
-                head -20 /tmp/new_tokens.txt | sed 's/.*/- `&`/'
-                if [ "$n" -gt 20 ]; then
-                  echo "- …and $((n - 20)) more"
+              list_tokens() { # $1: jq key order (added|removed), $2: heading
+                jq -r --slurpfile prev /tmp/prev.json "$1" categories.json > /tmp/tokens.txt
+                n=$(grep -c . /tmp/tokens.txt || true)
+                if [ "$n" -gt 0 ]; then
+                  echo ""
+                  echo "**${n} $2:**"
+                  head -20 /tmp/tokens.txt | sed 's/.*/- `&`/'
+                  if [ "$n" -gt 20 ]; then
+                    echo "- …and $((n - 20)) more"
+                  fi
                 fi
-              fi
+              }
+              list_tokens '(.tokenToCategory | keys) - ($prev[0].tokenToCategory | keys) | .[]' "new cask(s)"
+              list_tokens '($prev[0].tokenToCategory | keys) - (.tokenToCategory | keys) | .[]' "removed/deprecated cask(s)"
             fi
           } > /tmp/release_notes.md
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A daily GitHub Actions cron (`.github/workflows/classify-new-casks.yml`):
 5. Prunes removed/deprecated tokens.
 6. Opens a single rolling PR with the diff + classification report.
 
-On merge, `release.yml` cuts a `data-YYYY.MM.DD` tag with `categories.json` and a freshly mined `added_dates.json` attached as release assets.
+On merge, `release.yml` cuts a `caskflow-vYYYY.MM.DD` tag with `categories.json` and a freshly mined `added_dates.json` attached as release assets.
 
 ## Icons
 


### PR DESCRIPTION
- Release tags now `caskflow-vYYYY.MM.DD` (was `data-YYYY.MM.DD`); titles match the existing `CaskFlow-YYYY.MM.DD` style.
- Release notes now lead with the cask count and `generatedDate` read from `categories.json`, so the releases page shows what each drop contains at a glance.
- README updated to document the new tag scheme.

Existing releases were already migrated to `caskflow-v*` tags and the old experimental `cask-*` tags removed. Consumers are unaffected — CaskHub fetches via `releases/latest/download/`.