### PR TITLE
fix: truthful extract-icons CI reporting + monthly retry of parked casks

### DIFF
--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -13,10 +13,17 @@ on:
       tokens:
         description: "Specific tokens, space-separated (overrides limit)"
         default: ""
+      retry_parked:
+        description: "Retry all failed-parked tokens (overrides limit/tokens)"
+        type: boolean
+        default: false
   schedule:
-    # 15:43 UTC — after the 13:17 classification cron; a new cask usually
-    # gets its category and its icon on the same day.
+    # 15:43 UTC daily — after the 13:17 classification cron; a new cask
+    # usually gets its category and its icon on the same day.
     - cron: "43 15 * * *"
+    # Monthly: retry failed-parked tokens. sha256-mismatch parks heal once
+    # brew bumps the cask version; vendor-403 parks cost seconds to re-check.
+    - cron: "7 3 1 * *"
 
 permissions:
   contents: write
@@ -37,8 +44,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TOKENS: ${{ inputs.tokens }}
           LIMIT: ${{ inputs.limit || '300' }}
+          RETRY_PARKED: ${{ inputs.retry_parked }}
+          CRON: ${{ github.event.schedule }}
         run: |
-          if [ -n "$TOKENS" ]; then
+          if [ "$RETRY_PARKED" = "true" ] || [ "$CRON" = "7 3 1 * *" ]; then
+            python3 scripts/extract_icons.py --publish --retry-parked
+          elif [ -n "$TOKENS" ]; then
             # word-splitting intended: TOKENS is space-separated; the script
             # rejects anything that isn't a known cask token.
             python3 scripts/extract_icons.py --publish --tokens $TOKENS

--- a/docs/ICON_EXTRACTION.md
+++ b/docs/ICON_EXTRACTION.md
@@ -44,7 +44,12 @@ minutes on first request, cached aggressively thereafter.
 - **Done** = the `.png` files on the branch (one `git ls-tree`, no pagination).
 - `icon_report.json` records:
   - `no_icon` / `car_only` — permanently parked with a reason
-  - `failed` — retried up to 3 runs, then parked (`--tokens` bypasses parking)
+  - `failed` — retried up to 3 runs, then parked (`--tokens` bypasses parking;
+    a monthly cron re-runs all failed-parks via `--retry-parked`, since
+    sha256-mismatch parks heal once brew bumps the cask version).
+    A run where *every* cask in the batch fails exits non-zero (red CI run) —
+    it's either the tail-end dregs or a systemic problem worth a look; the
+    report/parking push happens before the exit, so nothing is lost.
   - `review` — icon published but the `.app` was picked heuristically
     (`single`/`shallowest`); **the human audit queue**. Eyeball these after
     each batch; a wrong-but-plausible icon is worse than a missing one.

--- a/scripts/extract_icons.py
+++ b/scripts/extract_icons.py
@@ -581,7 +581,10 @@ def _commit_and_push(wt: Path, pngs: dict[str, Path]) -> None:
     push = _git(wt, "push", "-q", "origin", f"HEAD:{ICONS_BRANCH}")
     if push.returncode != 0:
         raise ExtractError(f"icon push failed: {push.stderr.strip()[:200]}")
-    print(f"  ↑ published {len(pngs)} icons to {ICONS_BRANCH}")
+    if pngs:
+        print(f"  ↑ published {len(pngs)} icons to {ICONS_BRANCH}")
+    else:
+        print(f"  ↑ updated {REPORT_FILE} on {ICONS_BRANCH} (no new icons)")
 
 
 # ---------------------------------------------------------------------------
@@ -640,7 +643,16 @@ def _load_api_casks(casks_json: Path | None) -> list[dict]:
 
 
 def _build_batch(tokens: list[str] | None, by_token: dict[str, dict],
-                 api_casks: list[dict], report: dict, limit: int) -> list[dict]:
+                 api_casks: list[dict], report: dict, limit: int,
+                 retry_parked: bool = False) -> list[dict]:
+    if retry_parked:
+        # Monthly second chance for failed-parks only: sha256-mismatch parks
+        # heal once brew bumps the cask's version. no_icon/car_only parks are
+        # deterministic and never retried. Tokens gone from the API (removed
+        # casks) are skipped.
+        return [by_token[t] for t, e in sorted(report.items())
+                if e["status"] == "failed" and e.get("attempts", 0) >= MAX_ATTEMPTS
+                and t in by_token]
     if not tokens:
         return select_candidates(api_casks, report, limit)
     missing = [t for t in tokens if t not in by_token]
@@ -676,6 +688,8 @@ def _flush_if_due(report: dict, pending: dict[str, Path], dirty: set[str]) -> No
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--tokens", nargs="*", help="Extract exactly these casks")
+    parser.add_argument("--retry-parked", action="store_true",
+                        help="Retry every failed-parked token (attempts >= MAX_ATTEMPTS)")
     parser.add_argument("--limit", type=int, default=50, help="Batch cap (default 50)")
     parser.add_argument("--publish", action="store_true",
                         help="Publish cask-<token> pre-releases (requires gh auth)")
@@ -688,7 +702,8 @@ def main(argv: list[str] | None = None) -> int:
     by_token = {c["token"]: c for c in api_casks}
 
     report = load_report()
-    batch = _build_batch(args.tokens, by_token, api_casks, report, args.limit)
+    batch = _build_batch(args.tokens, by_token, api_casks, report, args.limit,
+                         retry_parked=args.retry_parked)
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
     print(f"Extracting {len(batch)} casks → {args.output_dir}"
@@ -712,7 +727,12 @@ def main(argv: list[str] | None = None) -> int:
         else:
             record(report, token, status, detail)
         outcomes.append((token, status, detail))
-        print(f"  [{i}/{len(batch)}] {token}: {status} — {detail}", flush=True)
+        note = ""
+        if status == "failed":
+            attempts = report[token]["attempts"]
+            note = (f" [attempt {attempts} — parked]" if attempts >= MAX_ATTEMPTS
+                    else f" [attempt {attempts}/{MAX_ATTEMPTS}]")
+        print(f"  [{i}/{len(batch)}] {token}: {status} — {detail}{note}", flush=True)
 
     if args.publish:
         # Always flush at the end — persists report-only outcomes (failures,
@@ -722,9 +742,17 @@ def main(argv: list[str] | None = None) -> int:
         print("(local run — report changes not persisted; use --publish)")
 
     elapsed = time.time() - start
+    failed = sum(1 for _, s, _ in outcomes if s == "failed")
     print(f"\n{ok}/{len(batch)} icons extracted in {elapsed:.0f}s; "
-          f"{sum(1 for _, s, _ in outcomes if s == 'failed')} failed, "
+          f"{failed} failed, "
           f"{sum(1 for _, s, _ in outcomes if s in ('no_icon', 'car_only'))} skipped")
+    if batch and failed == len(batch) and not args.retry_parked:
+        # Every cask hard-failed: either the tail-end dregs day (rare, worth a
+        # look) or a systemic problem (runner network, stale brew metadata).
+        # Report/parking is already pushed above, so failing here loses nothing.
+        # Retry-parked runs are exempt: all-fail is their expected outcome.
+        print("error: every cask in the batch failed — flagging the run red")
+        return 1
     return 0
 
 

--- a/tests/test_extract_icons.py
+++ b/tests/test_extract_icons.py
@@ -294,3 +294,59 @@ def test_icns_to_png_prefers_declared_catalog_icon_over_legacy_icns(tmp_path, mo
 def test_icns_to_png_no_icns_no_car_is_parked(tmp_path):
     app = _mk_app_with_resources(tmp_path)  # empty Resources
     assert icns_to_png(app, tmp_path / "out.png") == "no .icns in Resources"
+
+
+# --- main exit code --------------------------------------------------------
+
+def _run_main(monkeypatch, tmp_path, statuses):
+    import extract_icons
+    casks = [{"token": f"t{i}", "url": "https://example.com/a.dmg",
+              "artifacts": [{"app": ["A.app"]}]} for i in range(len(statuses))]
+    results = iter(statuses)
+    monkeypatch.setattr(extract_icons, "_load_api_casks", lambda p: casks)
+    monkeypatch.setattr(extract_icons, "load_report", lambda: {})
+    monkeypatch.setattr(extract_icons, "select_candidates", lambda a, r, l: casks)
+    monkeypatch.setattr(extract_icons, "_extract_status", lambda c, o: next(results))
+    return extract_icons.main(["--output-dir", str(tmp_path)])
+
+
+def test_main_all_failed_batch_exits_nonzero(monkeypatch, tmp_path):
+    # A batch where every cask hard-fails must flag the CI run red — a green
+    # run with "0 published, 40 failed" hides systemic breakage (2026-07-12).
+    assert _run_main(monkeypatch, tmp_path,
+                     [("failed", "boom"), ("failed", "boom")]) == 1
+
+
+def test_main_partial_failure_stays_green(monkeypatch, tmp_path):
+    # Individual failures are routine (MAX_ATTEMPTS retry design) — only a
+    # clean sweep of failures is an error signal.
+    assert _run_main(monkeypatch, tmp_path,
+                     [("failed", "boom"), ("no_icon", "no url")]) == 0
+    assert _run_main(monkeypatch, tmp_path, []) == 0  # empty batch: steady state
+
+
+# --- retry-parked ----------------------------------------------------------
+
+def test_build_batch_retry_parked_selects_failed_parked_only():
+    from extract_icons import _build_batch
+    by_token = {"a": {"token": "a"}, "b": {"token": "b"}, "c": {"token": "c"}}
+    report = {
+        "a": {"status": "failed", "attempts": 3},   # parked — retried
+        "b": {"status": "failed", "attempts": 2},   # daily cron still owns it
+        "c": {"status": "no_icon", "attempts": 0},  # deterministic — never retried
+        "gone": {"status": "failed", "attempts": 5},  # removed from brew API
+    }
+    batch = _build_batch(None, by_token, [], report, 50, retry_parked=True)
+    assert [c["token"] for c in batch] == ["a"]
+
+
+def test_main_retry_parked_all_fail_stays_green(monkeypatch, tmp_path):
+    # All-fail is the expected outcome of a speculative monthly retry —
+    # only the daily cron's all-fail flags the run red.
+    import extract_icons
+    casks = [{"token": "t0", "url": "u", "artifacts": [{"app": ["A.app"]}]}]
+    monkeypatch.setattr(extract_icons, "_load_api_casks", lambda p: casks)
+    monkeypatch.setattr(extract_icons, "load_report", lambda: {
+        "t0": {"status": "failed", "reason": "x", "attempts": 3, "updated": "2026-07-11"}})
+    monkeypatch.setattr(extract_icons, "_extract_status", lambda c, o: ("failed", "boom"))
+    assert extract_icons.main(["--output-dir", str(tmp_path), "--retry-parked"]) == 0

--- a/tests/test_extract_icons.py
+++ b/tests/test_extract_icons.py
@@ -305,7 +305,7 @@ def _run_main(monkeypatch, tmp_path, statuses):
     results = iter(statuses)
     monkeypatch.setattr(extract_icons, "_load_api_casks", lambda p: casks)
     monkeypatch.setattr(extract_icons, "load_report", lambda: {})
-    monkeypatch.setattr(extract_icons, "select_candidates", lambda a, r, l: casks)
+    monkeypatch.setattr(extract_icons, "select_candidates", lambda a, r, lim: casks)
     monkeypatch.setattr(extract_icons, "_extract_status", lambda c, o: next(results))
     return extract_icons.main(["--output-dir", str(tmp_path)])
 


### PR DESCRIPTION
## Summary
- The 2026-07-11 extract-icons run reported \`published 0 icons\` yet stayed green while all 40 casks failed — the failures were real (3rd strike, all now parked), but the reporting hid the story. This PR makes the CI output truthful and adds a low-cost recovery path for parked casks.
- \`_commit_and_push\` now distinguishes report-only pushes from icon pushes instead of printing "published 0 icons".
- Failed per-cask lines include attempt context: \`[attempt 1/3]\` / \`[attempt 4 — parked]\`.
- A run where **every** cask in the batch hard-fails exits 1 (red run): either the tail-end dregs or systemic breakage (runner network, stale brew metadata). The report/parking push happens before the exit, so nothing is lost.
- New \`--retry-parked\` flag re-runs failed-parked tokens (attempts >= 3) only — never the deterministic \`no_icon\`/\`car_only\` parks — and skips tokens removed from the brew API. Wired to a monthly cron (\`7 3 1 * *\`) plus a manual \`retry_parked\` dispatch input. Retry runs are exempt from the red-run rule since all-fail is their expected outcome; a success pops the report entry (unparked, icon published).

Rationale: most failed-parks are sha256 mismatches that heal once brew bumps the cask version; a monthly sweep recovers those for free. Vendor-403 parks cost seconds to re-check.

## Test plan
- [x] \`pytest\` — 55 passed (4 new: exit-code rule, retry-parked selection and exemption)
- [x] Smoke-ran \`main()\` with stubbed extraction: verified new log lines, red exit on all-fail daily batch, green exit on all-fail retry batch
- [x] Workflow YAML parses; new inputs pass through \`env:\` like the existing \`TOKENS\`