### PR TITLE
feat: stamp the release tag into the categories.json asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,16 @@ jobs:
           echo "tag=caskflow-v$d" >> "$GITHUB_OUTPUT"
           echo "date=$d" >> "$GITHUB_OUTPUT"
 
+      # Stamp the tag into the asset so consumers can display the release
+      # their data actually came from, without a separate GitHub API call.
+      - name: Stamp release tag into categories.json
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          jq --arg tag "$TAG" '. + {releaseTag: $tag}' \
+            categories.json > /tmp/stamped.json
+          mv /tmp/stamped.json categories.json
+
       - name: Compose release notes
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds a `releaseTag` field (e.g. `caskflow-v2026.07.10`) to `categories.json` at release time, so consumers can display which release their data came from without a separate GitHub API call.

- Stamped with `jq` right after the tag is computed, before release notes and upload.
- The release-notes diff only reads `tokenToCategory`, so it's unaffected.
- CaskHub's status bar reads this field once it ships in a release.