### PR TITLE
ci: Publish icons-branch manifest in released categories.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,22 @@ jobs:
 
       # Stamp the tag into the asset so consumers can display the release
       # their data actually came from, without a separate GitHub API call.
-      - name: Stamp release tag into categories.json
+      # iconTokens is the manifest of the icons branch — CaskHub skips icon
+      # requests for any token not listed (they are guaranteed 404s). If the
+      # trees API fails or truncates, the field is omitted and the app falls
+      # back to probing, so this step must never fail the release.
+      - name: Stamp release tag and icon manifest into categories.json
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          jq --arg tag "$TAG" '. + {releaseTag: $tag}' \
+          gh api "repos/$REPO/git/trees/icons" --jq \
+            'if .truncated then null else
+               [.tree[].path | select(endswith(".png")) | rtrimstr(".png")]
+             end' > /tmp/icon_manifest.json || echo null > /tmp/icon_manifest.json
+          jq --arg tag "$TAG" --slurpfile icons /tmp/icon_manifest.json \
+            '. + {releaseTag: $tag}
+             + (if $icons[0] then {iconTokens: ($icons[0] | sort)} else {} end)' \
             categories.json > /tmp/stamped.json
           mv /tmp/stamped.json categories.json
 


### PR DESCRIPTION
## Why

CaskHub requests CaskFlow icons for every visible cask, but **352 of the 3,803 catalog casks have no icon on the icons branch** — each one costs up to three guaranteed-404 probes per day (jsdelivr + raw.githubusercontent, plus AppFair for app casks), and every AppFair-sourced icon re-probes CaskFlow daily hoping an icon appeared. The CLI casks visible in Proxyman (`copilot-cli`, `gcloud-cli`, `codex`, `ngrok`, `claude-code`) were just the recognizable tip.

## What

The release workflow already stamps `releaseTag` into `categories.json`; this adds `iconTokens` — the full manifest of the icons branch (currently 3,507 tokens), fetched via the git trees API (no blob download) and stamped in the same step. CaskHub gates all CaskFlow icon requests on it:

- any cask missing from the manifest skips both CaskFlow URLs (CLI casks skip entirely — they keep the live `>_` tile)
- the AppFair fallback-upgrade path only fires for tokens actually in the manifest
- the field is optional and `version` stays 2, so old assets and the app's remote-refresh gate are unaffected
- on trees-API failure or truncation the field is omitted and the app falls back to today's probe-once-per-24h behavior

Verified locally: the exact `gh api` + `jq` pipeline emits 3,507 sorted tokens (3,509 branch files minus `README.md` and `icon_report.json`) alongside the existing fields.

Companion CaskHub change gates `ImageCacheService` on the manifest (covered by tests asserting which hosts get hit).