### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/.github/workflows/classify-new-casks.yml
+++ b/.github/workflows/classify-new-casks.yml
@@ -75,6 +75,6 @@ jobs:
           GH_TOKEN: ${{ secrets.CLASSIFY_BOT_TOKEN || github.token }}
           PR: ${{ steps.pr.outputs.pull-request-number }}
         run: |
-          if [ "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest')" = "null" ]; then
+          if [ "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]; then
             gh pr merge --auto --squash "$PR"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,18 @@ on:
     branches: [master]
     paths:
       - categories.json
+  # Recently Added is independent of classification. Refresh its mined dates
+  # every day even when a classification PR is delayed or has nothing to merge.
+  schedule:
+    - cron: "47 14 * * *"
   workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: caskflow-data-release
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -48,17 +56,20 @@ jobs:
 
       - name: Compose release notes
         env:
+          EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
         run: |
           count=$(jq -r .totalCasks categories.json)
           generated=$(jq -r .generatedDate categories.json)
           {
-            echo "Daily classification update — **${count} casks**, generated ${generated}."
+            echo "Daily data update — **${count} categorized casks**. Categories generated ${generated}; added dates refreshed ${{ steps.tag.outputs.date }}."
 
-            pr=$(gh api "repos/$REPO/commits/${{ github.sha }}/pulls" --jq '.[0].number' || true)
-            if [ -n "$pr" ]; then
-              echo ""
-              echo "Changes: #${pr}"
+            if [ "$EVENT_NAME" = "push" ]; then
+              pr=$(gh api "repos/$REPO/commits/${{ github.sha }}/pulls" --jq '.[0].number' || true)
+              if [ -n "$pr" ]; then
+                echo ""
+                echo "Classification changes: #${pr}"
+              fi
             fi
 
             # Diff against the previous release (still "latest" at this point)
@@ -89,6 +100,7 @@ jobs:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: "CaskFlow-${{ steps.tag.outputs.date }}"
           body_path: /tmp/release_notes.md
+          overwrite_files: true
           files: |
             categories.json
             added_dates.json

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A daily GitHub Actions cron (`.github/workflows/classify-new-casks.yml`):
 5. Prunes removed/deprecated tokens.
 6. Opens a single rolling PR with the diff + classification report.
 
-On merge, `release.yml` cuts a `caskflow-vYYYY.MM.DD` tag with `categories.json` and a freshly mined `added_dates.json` attached as release assets.
+`release.yml` publishes `categories.json` and a freshly mined `added_dates.json` as release assets every day, independently of classification. A category merge also triggers it immediately, so classification updates do not delay Recently Added data and date refreshes do not require an LLM result.
 
 ## Icons
 

--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-07-18",
-  "totalCasks": 3807,
+  "generatedDate": "2026-07-22",
+  "totalCasks": 3817,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -2114,6 +2114,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "cate": {
+      "primary": "developerTools",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "catlight": {
       "primary": "developerTools",
       "secondary": []
@@ -2408,6 +2414,13 @@
         "ai"
       ]
     },
+    "claude-status-bar": {
+      "primary": "menuBar",
+      "secondary": [
+        "developerTools",
+        "ai"
+      ]
+    },
     "claudebar": {
       "primary": "menuBar",
       "secondary": [
@@ -2429,6 +2442,12 @@
     "cleanmymac": {
       "primary": "utilities",
       "secondary": []
+    },
+    "cleanmymac-cli": {
+      "primary": "utilities",
+      "secondary": [
+        "developerTools"
+      ]
     },
     "cleanmymac-zh": {
       "primary": "utilities",
@@ -7380,6 +7399,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "libation": {
+      "primary": "audioMusic",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "libcblite": {
       "primary": "developerTools",
       "secondary": []
@@ -7463,6 +7488,12 @@
     "lingon-x": {
       "primary": "utilities",
       "secondary": []
+    },
+    "linguax": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
     },
     "linkandroid": {
       "primary": "utilities",
@@ -9297,6 +9328,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "neon-vision-editor": {
+      "primary": "developerTools",
+      "secondary": [
+        "productivity"
+      ]
+    },
     "neovide-app": {
       "primary": "developerTools",
       "secondary": []
@@ -9904,6 +9941,12 @@
       "primary": "scienceEducation",
       "secondary": [
         "utilities"
+      ]
+    },
+    "opendisplay": {
+      "primary": "utilities",
+      "secondary": [
+        "videoMedia"
       ]
     },
     "openforis-collect": {
@@ -11114,6 +11157,12 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "prisma-access-browser": {
+      "primary": "browsers",
+      "secondary": [
+        "securityPrivacy"
+      ]
+    },
     "prisma-studio": {
       "primary": "designGraphics",
       "secondary": []
@@ -12132,6 +12181,10 @@
       "primary": "audioMusic",
       "secondary": []
     },
+    "roslynpad": {
+      "primary": "developerTools",
+      "secondary": []
+    },
     "rotato": {
       "primary": "designGraphics",
       "secondary": []
@@ -12559,6 +12612,13 @@
     "sessionrestore": {
       "primary": "productivity",
       "secondary": []
+    },
+    "sessionwatcher": {
+      "primary": "menuBar",
+      "secondary": [
+        "developerTools",
+        "ai"
+      ]
     },
     "setapp": {
       "primary": "utilities",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,10 +1,10 @@
 # Daily classification update
 
-Generated 2026-07-18
+Generated 2026-07-22
 
 ## Summary
 
-- 4 new casks classified
+- 10 new casks classified
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
@@ -14,7 +14,13 @@ Generated 2026-07-18
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `aphera` | designGraphics | — | 0.95 | Aphera is a RAW photo editing application, fitting design/graphics tools. |
-| `arcbox` | developerTools | utilities | 0.85 | Container/VM runtime tool similar to Docker Desktop, aimed at developers. |
-| `logseq-og` | productivity | developerTools | 0.85 | Logseq is a note-taking/knowledge management app, with open-source developer roots. |
-| `perplexity` | productivity | ai | 0.85 | Perplexity is an AI answer-engine/assistant app, fitting productivity with an AI trait. |
+| `cate` | developerTools | productivity | 0.70 | A canvas-based coding environment combining terminal, editor, and browser panels for developers. |
+| `claude-status-bar` | menuBar | developerTools, ai | 0.85 | A menu bar status indicator specifically for monitoring Claude Code, an AI coding tool. |
+| `cleanmymac-cli` | utilities | developerTools | 0.85 | CLI tool for cleaning system and developer caches to reclaim disk space, targeted at developers. |
+| `libation` | audioMusic | utilities | 0.85 | Manages and downloads Audible audiobooks, an audio content management tool. |
+| `linguax` | utilities | menuBar | 0.75 | Menu-bar utility that enhances third-party mouse functionality with mapping and input automation, a system-level input utility. |
+| `neon-vision-editor` | developerTools | productivity | 0.85 | A lightweight native code/text editor with syntax highlighting is primarily a developer tool. |
+| `opendisplay` | utilities | videoMedia | 0.85 | System-level display utility turning iOS devices into extended Mac displays. |
+| `prisma-access-browser` | browsers | securityPrivacy | 0.85 | It's a secure enterprise web browser with built-in security features. |
+| `roslynpad` | developerTools | — | 0.95 | RoslynPad is a C# code editor and runner built on Roslyn, a developer tool. |
+| `sessionwatcher` | menuBar | developerTools, ai | 0.85 | Menu bar app that tracks AI coding assistant usage, costs, and rate limits. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -3676,6 +3676,13 @@
     "og_desc": ""
   },
   {
+    "token": "cate",
+    "homepage": "https://cate.cero-ai.com/",
+    "title": "CATE · Canvas Terminal Editor",
+    "meta_desc": "An infinite zoomable canvas where terminals, editors, and browsers float spatially. Code the way you think.",
+    "og_desc": "An infinite zoomable canvas where terminals, editors, and browsers float spatially. Code the way you think."
+  },
+  {
     "token": "catlight",
     "homepage": "https://catlight.io/",
     "title": "CatLight - Action Center for Developers",
@@ -4163,6 +4170,13 @@
     "og_desc": "The missing DevTools for Claude Code — inspect session logs, tool calls, token usage, subagents, and context window in a visual UI. Free, open source. - matt1398/claude-devtools"
   },
   {
+    "token": "claude-status-bar",
+    "homepage": "https://github.com/m1ckc3s/claude-status-bar",
+    "title": "GitHub - m1ckc3s/claude-status-bar: Menu bar status indicator for Claude Code · GitHub",
+    "meta_desc": "Menu bar status indicator for Claude Code. Contribute to m1ckc3s/claude-status-bar development by creating an account on GitHub.",
+    "og_desc": "Menu bar status indicator for Claude Code. Contribute to m1ckc3s/claude-status-bar development by creating an account on GitHub."
+  },
+  {
     "token": "claudebar",
     "homepage": "https://github.com/tddworks/ClaudeBar",
     "title": "GitHub - tddworks/ClaudeBar: A macOS menu bar application that monitors AI coding assistant usage quotas. Keep track of your Claude, Codex, Antigravity ,and Gemini usage at a glance. · GitHub",
@@ -4203,6 +4217,13 @@
     "title": "CleanMyMac: The best Mac cleaner & maintenance software",
     "meta_desc": "CleanMyMac is the best Mac cleaner app that helps you clean, maintain, and protect your Mac — trusted by millions. Try it and organize your Mac in a few clicks. ",
     "og_desc": "CleanMyMac is the best Mac cleaner app that helps you clean, maintain, and protect your Mac — trusted by millions. Try it and organize your Mac in a few clicks. "
+  },
+  {
+    "token": "cleanmymac-cli",
+    "homepage": "https://github.com/MacPaw/cleanmymac-cli",
+    "title": "GitHub - MacPaw/cleanmymac-cli: Clean Xcode, Docker, Homebrew, and developer caches, remove project and AI artifacts, analyze storage, and reclaim disk space from the Terminal. · GitHub",
+    "meta_desc": "Clean Xcode, Docker, Homebrew, and developer caches, remove project and AI artifacts, analyze storage, and reclaim disk space from the Terminal. - MacPaw/cleanmymac-cli",
+    "og_desc": "Clean Xcode, Docker, Homebrew, and developer caches, remove project and AI artifacts, analyze storage, and reclaim disk space from the Terminal. - MacPaw/cleanmymac-cli"
   },
   {
     "token": "cleanmymac-zh",
@@ -30843,6 +30864,13 @@
     "og_desc": ""
   },
   {
+    "token": "libation",
+    "homepage": "https://getlibation.com/",
+    "title": "Libation",
+    "meta_desc": "Libation: Liberate your Library - A free application for downloading your Audible audiobooks",
+    "og_desc": ""
+  },
+  {
     "token": "libcblite",
     "homepage": "https://www.couchbase.com/products/lite",
     "error": "HTTP 403"
@@ -30989,6 +31017,13 @@
     "title": "Lingon - Peter Borg Apps",
     "meta_desc": "Run whatever you want, whenever you want with Lingon. Simple scheduling, menu bar control, and powerful Pro features.",
     "og_desc": ""
+  },
+  {
+    "token": "linguax",
+    "homepage": "https://linguax.app/",
+    "title": "LinguaX – Mouse Enhancement, Push-to-Talk & Input Automation for macOS | LinguaX",
+    "meta_desc": "LinguaX gives third-party mice a pro macOS feel — smooth scrolling, gesture and side-button mapping, and push-to-talk voice typing — plus automatic input-source switching. Free trial, $9.9 lifetime.",
+    "og_desc": "LinguaX gives third-party mice a pro macOS feel — smooth scrolling, gesture and side-button mapping, and push-to-talk voice typing — plus automatic input-source switching. Free trial, $9.9 lifetime."
   },
   {
     "token": "linkandroid",
@@ -34367,6 +34402,13 @@
     "og_desc": "A beautiful, efficient system monitor built with Rust and Svelte. Monitor processes, CPU, and memory usage in real-time."
   },
   {
+    "token": "neon-vision-editor",
+    "homepage": "https://github.com/h3pdesign/Neon-Vision-Editor",
+    "title": "GitHub - h3pdesign/Neon-Vision-Editor: Neon Vision Editor - A lightweight, modern code & text editor for macOS built for speed, readability, and automatic syntax highlighting — minimal by design, with fast file access and a focused editing experience. · GitHub",
+    "meta_desc": "Neon Vision Editor - A lightweight, modern code & text editor for macOS built for speed, readability, and automatic syntax highlighting — minimal by design, with fast file access and a focused editing experience. - h3pdesign/Neon-Vision-Editor",
+    "og_desc": "Neon Vision Editor - A lightweight, modern code &amp; text editor for macOS built for speed, readability, and automatic syntax highlighting — minimal by design, with fast file access and a focused ..."
+  },
+  {
     "token": "neovide-app",
     "homepage": "https://github.com/neovide/neovide",
     "title": "GitHub - neovide/neovide: No Nonsense Neovim Client in Rust · GitHub",
@@ -35435,6 +35477,13 @@
     "title": "OpenCPN Official Site",
     "meta_desc": "Official site of OpenCPN Chart Plotter Navigation software. Thousands of boaters already use OpenCPN as their main navigational tool. You can too. Its open source.",
     "og_desc": ""
+  },
+  {
+    "token": "opendisplay",
+    "homepage": "https://opendisplay.app/",
+    "title": "OpenDisplay — Turn your spare Apple devices into second monitors for your Mac (free & open source)",
+    "meta_desc": "OpenDisplay is a free, open-source alternative to Apple Sidecar and Duet Display. Turn your spare Apple devices — iPhone and iPad today, Macs on the roadmap — into true extended displays for your Mac over USB or WiFi. Retina-sharp, low latency, with touch and scroll input. No subscription, no dongle, no account.",
+    "og_desc": "Use your iPhone or iPad as a second monitor for your Mac. A true extended display over USB or WiFi — Retina-sharp, low latency, with touch and scroll. No subscription, no dongle, no account."
   },
   {
     "token": "opendnsupdater",
@@ -37598,6 +37647,13 @@
     "og_desc": ""
   },
   {
+    "token": "prisma-access-browser",
+    "homepage": "https://get.pabrowser.com/welcome",
+    "title": "Get Prisma Browser",
+    "meta_desc": "",
+    "og_desc": ""
+  },
+  {
     "token": "prisma-studio",
     "homepage": "https://www.prisma.io/studio",
     "title": "Prisma Studio — Visual Database Browser & Editor",
@@ -39389,6 +39445,13 @@
     "og_desc": ""
   },
   {
+    "token": "roslynpad",
+    "homepage": "https://roslynpad.net/",
+    "title": "RoslynPad",
+    "meta_desc": "Cross-platform C# code editor and runner. Built with Roslyn.",
+    "og_desc": ""
+  },
+  {
     "token": "rotato",
     "homepage": "https://rotato.app/",
     "title": "Mockup Generator & Animator 3D | Rotato",
@@ -40193,6 +40256,13 @@
     "title": "SessionRestore by SweetP Productions",
     "meta_desc": "advanced Safari session management",
     "og_desc": ""
+  },
+  {
+    "token": "sessionwatcher",
+    "homepage": "https://www.sessionwatcher.com/",
+    "title": "SessionWatcher - Track AI Coding Usage on macOS",
+    "meta_desc": "SessionWatcher tracks Claude, Codex, Copilot, Cursor and Gemini usage, costs and rate limits live in your macOS menu bar. Stop getting locked out mid-session. From $6.99 one-time.",
+    "og_desc": "SessionWatcher tracks Claude, Codex, Copilot, Cursor and Gemini usage, costs and rate limits live in your macOS menu bar. Stop getting locked out mid-session. From $6.99 one-time."
   },
   {
     "token": "setapp",

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -1,0 +1,25 @@
+"""Regression tests for data-publication and classification workflow contracts."""
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _workflow(name: str) -> str:
+    return (REPO_ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+
+
+def test_added_dates_publish_independently_of_category_changes():
+    release = _workflow("release.yml")
+
+    assert "schedule:" in release
+    assert 'cron: "47 14 * * *"' in release
+    assert "python3 scripts/mine_added_dates.py" in release
+    assert "overwrite_files: true" in release
+
+
+def test_auto_merge_checks_null_as_a_boolean():
+    classification = _workflow("classify-new-casks.yml")
+
+    assert "--jq '.autoMergeRequest != null'" in classification
+    assert "--jq '.autoMergeRequest')\" = \"null\"" not in classification


### PR DESCRIPTION
# Daily classification update

Generated 2026-07-22

## Classification summary

- 10 new casks classified
- 0 new casks **skipped**
- 0 casks renamed
- 0 casks removed or deprecated

| token | primary | secondary | confidence |
|---|---|---|---|
| `cate` | developerTools | productivity | 0.70 |
| `claude-status-bar` | menuBar | developerTools, ai | 0.85 |
| `cleanmymac-cli` | utilities | developerTools | 0.85 |
| `libation` | audioMusic | utilities | 0.85 |
| `linguax` | utilities | menuBar | 0.75 |
| `neon-vision-editor` | developerTools | productivity | 0.85 |
| `opendisplay` | utilities | videoMedia | 0.85 |
| `prisma-access-browser` | browsers | securityPrivacy | 0.85 |
| `roslynpad` | developerTools | — | 0.95 |
| `sessionwatcher` | menuBar | developerTools, ai | 0.85 |

## Recently Added pipeline fix

This PR also removes the accidental dependency between classification and CaskHub's Recently Added feed:

- `added_dates.json` is now mined and published daily even if no category change merges.
- Data releases continue to include both the current `categories.json` and fresh `added_dates.json`, preserving the stable `releases/latest/download/...` URLs.
- Category merges still trigger an immediate data release.
- Same-day release runs are serialized and replace existing assets deterministically.
- Scheduled release notes no longer attribute an unrelated PR as a classification change.
- The rolling PR auto-merge guard now checks JSON null as a boolean; the previous string comparison always skipped `gh pr merge --auto`.

## Validation

- 57 tests pass, including two new workflow-contract regressions.
- Workflow YAML parses successfully.
- Category mappings are internally valid: 3,817 declared and mapped tokens.
- Homepage metadata contains unique token rows.
- All ten additions exist in Homebrew's live cask catalog.
