### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-07-22",
-  "totalCasks": 3817,
+  "generatedDate": "2026-07-23",
+  "totalCasks": 3819,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -9810,6 +9810,12 @@
       "primary": "communication",
       "secondary": []
     },
+    "onit-sidekick": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
+    },
     "onlook": {
       "primary": "designGraphics",
       "secondary": []
@@ -10067,6 +10073,12 @@
     "openwebstart": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "openwhispr": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "openwork": {
       "primary": "developerTools",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,10 +1,11 @@
 # Daily classification update
 
-Generated 2026-07-22
+Generated 2026-07-23
 
 ## Summary
 
-- 10 new casks classified
+- 2 new casks classified
+- 1 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
@@ -14,13 +15,11 @@ Generated 2026-07-22
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `cate` | developerTools | productivity | 0.70 | A canvas-based coding environment combining terminal, editor, and browser panels for developers. |
-| `claude-status-bar` | menuBar | developerTools, ai | 0.85 | A menu bar status indicator specifically for monitoring Claude Code, an AI coding tool. |
-| `cleanmymac-cli` | utilities | developerTools | 0.85 | CLI tool for cleaning system and developer caches to reclaim disk space, targeted at developers. |
-| `libation` | audioMusic | utilities | 0.85 | Manages and downloads Audible audiobooks, an audio content management tool. |
-| `linguax` | utilities | menuBar | 0.75 | Menu-bar utility that enhances third-party mouse functionality with mapping and input automation, a system-level input utility. |
-| `neon-vision-editor` | developerTools | productivity | 0.85 | A lightweight native code/text editor with syntax highlighting is primarily a developer tool. |
-| `opendisplay` | utilities | videoMedia | 0.85 | System-level display utility turning iOS devices into extended Mac displays. |
-| `prisma-access-browser` | browsers | securityPrivacy | 0.85 | It's a secure enterprise web browser with built-in security features. |
-| `roslynpad` | developerTools | - | 0.95 | RoslynPad is a C# code editor and runner built on Roslyn, a developer tool. |
-| `sessionwatcher` | menuBar | developerTools, ai | 0.85 | Menu bar app that tracks AI coding assistant usage, costs, and rate limits. |
+| `onit-sidekick` | productivity | ai | 0.60 | An AI chat sidebar/panel tool that assists productivity, powered by AI, despite homepage metadata referencing a different voice product. |
+| `openwhispr` | productivity | ai | 0.85 | Voice-to-text dictation tool using AI models fits productivity with an AI trait. |
+
+## Manual review required
+
+| token | primary | secondary | confidence | reason |
+|---|---|---|---|---|
+| `onit-sidekick` | productivity | ai | 0.60 | An AI chat sidebar/panel tool that assists productivity, powered by AI, despite homepage metadata referencing a different voice product. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -35290,6 +35290,13 @@
     "og_desc": ""
   },
   {
+    "token": "onit-sidekick",
+    "homepage": "https://www.cloudless.so/ai-sidebar",
+    "title": "Cloudless Voice - The Free Alternative to Wispr Flow",
+    "meta_desc": "Seriously fast voice dictation that runs locally on Mac, Windows and iOS. See what your laptop is capable of. ",
+    "og_desc": "Seriously fast voice dictation that runs locally on Mac, Windows and iOS. See what your laptop is capable of. "
+  },
+  {
     "token": "onlook",
     "homepage": "https://onlook.com/",
     "title": "Onlook - Cursor for Designers",
@@ -35750,6 +35757,13 @@
     "title": "Java Web Start is dead. Long live OpenWebStart! - openwebstart.com",
     "meta_desc": "OWS is the enterprise-ready open source reimplementation of Java Web Start technology providing common features of JWS and the JNLP standard.",
     "og_desc": "OWS is the enterprise-ready open source reimplementation of Java Web Start technology providing common features of JWS and the JNLP standard."
+  },
+  {
+    "token": "openwhispr",
+    "homepage": "https://github.com/OpenWhispr/openwhispr",
+    "title": "GitHub - OpenWhispr/openwhispr: Voice-to-text dictation app with local (Nvidia Parakeet/Whisper) and cloud models (BYOK). Privacy-first and available cross-platform. · GitHub",
+    "meta_desc": "Voice-to-text dictation app with local (Nvidia Parakeet/Whisper) and cloud models (BYOK). Privacy-first and available cross-platform. - OpenWhispr/openwhispr",
+    "og_desc": "Voice-to-text dictation app with local (Nvidia Parakeet/Whisper) and cloud models (BYOK). Privacy-first and available cross-platform. - OpenWhispr/openwhispr"
   },
   {
     "token": "openwork",


### PR DESCRIPTION
# Daily classification update

Generated 2026-07-23

## Summary

- 2 new casks classified
- 1 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `onit-sidekick` | productivity | ai | 0.60 | An AI chat sidebar/panel tool that assists productivity, powered by AI, despite homepage metadata referencing a different voice product. |
| `openwhispr` | productivity | ai | 0.85 | Voice-to-text dictation tool using AI models fits productivity with an AI trait. |

## Manual review required

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `onit-sidekick` | productivity | ai | 0.60 | An AI chat sidebar/panel tool that assists productivity, powered by AI, despite homepage metadata referencing a different voice product. |
