### PR TITLE
fix: Correct PR assignment and added dates

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  pull-requests: write
 
 jobs:
   assign:

--- a/scripts/mine_added_dates.py
+++ b/scripts/mine_added_dates.py
@@ -48,9 +48,11 @@ def mine(repo: Path) -> dict[str, str]:
     log = subprocess.run(  # nosec B603 - fixed executable and argument list; shell is never used
         [
             GIT_EXECUTABLE, "-C", str(repo), "log",
+            "--first-parent", "--diff-merges=first-parent",
             "--diff-filter=A", "--no-renames", "--name-status",
-            # Committer date = when it landed in the tap (author date can
-            # predate the merge by days on slow PRs).
+            # Follow the default branch and compare merge commits with their
+            # first parent. Feature-branch commit dates can predate the merge
+            # by days, while the first-parent commit records when they landed.
             "--date=short", "--format=%cd",
             "--", "Casks/",
         ],

--- a/tests/test_mine_added_dates.py
+++ b/tests/test_mine_added_dates.py
@@ -78,6 +78,59 @@ def test_mines_cask_that_has_no_category(tmp_path):
     assert validate_current_cask_coverage(repo, added) == set()
 
 
+def test_mines_default_branch_landing_date_for_delayed_merge(tmp_path):
+    repo = tmp_path / "homebrew-cask"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "master", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+
+    readme = repo / "README.md"
+    readme.write_text("tap\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", str(readme)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "Initialize tap"],
+        check=True,
+    )
+
+    subprocess.run(["git", "-C", str(repo), "switch", "-q", "-c", "new-cask"], check=True)
+    cask = repo / "Casks" / "o" / "openwhispr.rb"
+    cask.parent.mkdir(parents=True)
+    cask.write_text('cask "openwhispr" do\nend\n', encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", str(cask)], check=True)
+    feature_env = os.environ | {
+        "GIT_AUTHOR_DATE": "2026-07-16T10:00:00Z",
+        "GIT_COMMITTER_DATE": "2026-07-16T10:00:00Z",
+    }
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "Add OpenWhispr"],
+        check=True,
+        env=feature_env,
+    )
+
+    subprocess.run(["git", "-C", str(repo), "switch", "-q", "master"], check=True)
+    readme.write_text("tap history\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", str(readme)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "Advance default branch"],
+        check=True,
+    )
+    merge_env = os.environ | {
+        "GIT_AUTHOR_DATE": "2026-07-23T09:27:47Z",
+        "GIT_COMMITTER_DATE": "2026-07-23T09:27:47Z",
+    }
+    subprocess.run(
+        ["git", "-C", str(repo), "merge", "-q", "--no-ff", "new-cask", "-m", "Merge cask"],
+        check=True,
+        env=merge_env,
+    )
+
+    assert mine(repo)["openwhispr"] == "2026-07-23"
+
+
 def test_coverage_check_catches_an_active_cask_without_a_date(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "mine_added_dates.current_cask_tokens",

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -23,3 +23,10 @@ def test_auto_merge_checks_null_as_a_boolean():
 
     assert "--jq '.autoMergeRequest != null'" in classification
     assert "--jq '.autoMergeRequest')\" = \"null\"" not in classification
+
+
+def test_pr_hygiene_can_assign_pull_requests():
+    hygiene = _workflow("pr-hygiene.yml")
+
+    assert "pull-requests: write" in hygiene
+    assert "issues: write" not in hygiene


### PR DESCRIPTION
## Summary

- grant the PR hygiene workflow explicit pull request write permission
- mine cask dates from default-branch landing commits instead of feature-branch commit timestamps
- add regression coverage for both workflow contracts

## Root causes

- the assignment step targets a pull request, but the workflow token only had issues write permission, so GitHub returned HTTP 403
- a cask commit can predate the merge that makes it available on Homebrew master; plain git log followed the feature commit timestamp instead of first-parent landing history

OpenWhispr demonstrates the second case: its feature commit was dated July 16, 2026, while the Homebrew pull request landed on July 23, 2026.

## Verification

- [x] 96 tests pass
- [x] 60.59% test coverage
- [x] full Homebrew history validation produced 11,894 active dates with zero missing tokens and OpenWhispr dated 2026-07-23