### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-07-25",
-  "totalCasks": 3831,
+  "generatedDate": "2026-07-27",
+  "totalCasks": 3832,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -452,6 +452,12 @@
     "airserver": {
       "primary": "utilities",
       "secondary": []
+    },
+    "airsync": {
+      "primary": "utilities",
+      "secondary": [
+        "communication"
+      ]
     },
     "airtable": {
       "primary": "productivity",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,11 +1,11 @@
 # Daily classification update
 
-Generated 2026-07-25
+Generated 2026-07-27
 
 ## Summary
 
-- 11 new casks classified
-- 2 classifications require manual review (confidence below 0.75)
+- 1 new casks classified
+- 1 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
@@ -15,21 +15,10 @@ Generated 2026-07-25
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `billy` | financeCrypto | productivity | 0.85 | Billy is an invoicing tool for freelancers, fitting finance-related invoice management. |
-| `block-buzz` | communication | ai, productivity | 0.60 | A workspace/communication platform for humans and AI agents, blending team chat with AI collaboration features. |
-| `changes` | developerTools | - | 0.97 | An open source Git GUI client for macOS is a developer version-control tool. |
-| `clarc` | developerTools | ai | 0.85 | Desktop GUI client for Claude Code, an AI coding assistant tool aimed at developers. |
-| `codexia` | developerTools | ai | 0.85 | A GUI/toolkit for Codex CLI and Claude Code targeting developers with git worktree and task scheduling features, powered by AI coding agents. |
-| `dnclient-server` | securityPrivacy | utilities | 0.85 | A VPN client daemon for encrypted peer-to-peer networking is fundamentally a network security tool. |
-| `gamehub` | games | utilities | 0.85 | A compatibility layer/launcher for playing Windows and Steam games on Mac focuses on game play rather than development. |
-| `hermes-desktop` | productivity | ai | 0.75 | Desktop AI agent app for conversational assistance, similar to AI chatbot clients categorized under productivity with ai trait. |
-| `koe` | productivity | ai, utilities | 0.70 | A voice-to-text hotkey tool that pastes corrected text into apps, likely using AI transcription/correction, fitting productivity with AI trait. |
-| `moonfin` | videoMedia | - | 0.95 | Moonfin is a media streaming client for Jellyfin/Emby, focused on video playback. |
-| `neodisk` | utilities | - | 0.95 | Disk space visualizer is a classic system utility for analyzing storage usage. |
+| `airsync` | utilities | communication | 0.65 | Continuity-style tool syncing Android devices with macOS, primarily a system utility bridging device notifications/data. |
 
 ## Manual review required
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `block-buzz` | communication | ai, productivity | 0.60 | A workspace/communication platform for humans and AI agents, blending team chat with AI collaboration features. |
-| `koe` | productivity | ai, utilities | 0.70 | A voice-to-text hotkey tool that pastes corrected text into apps, likely using AI transcription/correction, fitting productivity with AI trait. |
+| `airsync` | utilities | communication | 0.65 | Continuity-style tool syncing Android devices with macOS, primarily a system utility bridging device notifications/data. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -712,6 +712,13 @@
     "og_desc": ""
   },
   {
+    "token": "airsync",
+    "homepage": "https://github.com/sameerasw/airsync-mac",
+    "title": "GitHub - sameerasw/airsync-mac: AirSync macOS - Bring the forbidden macOS continuity to Android · GitHub",
+    "meta_desc": "AirSync macOS - Bring the forbidden macOS continuity to Android - sameerasw/airsync-mac",
+    "og_desc": "AirSync macOS - Bring the forbidden macOS continuity to Android - sameerasw/airsync-mac"
+  },
+  {
     "token": "airtable",
     "homepage": "https://airtable.com/",
     "title": "Airtable: Build Enterprise-ready AI Workflows, Apps & Agents - Airtable",


### PR DESCRIPTION
# Daily classification update

Generated 2026-07-27

## Summary

- 1 new casks classified
- 1 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `airsync` | utilities | communication | 0.65 | Continuity-style tool syncing Android devices with macOS, primarily a system utility bridging device notifications/data. |

## Manual review required

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `airsync` | utilities | communication | 0.65 | Continuity-style tool syncing Android devices with macOS, primarily a system utility bridging device notifications/data. |
