### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-07-27",
-  "totalCasks": 3832,
+  "generatedDate": "2026-07-28",
+  "totalCasks": 3831,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -8521,10 +8521,6 @@
     },
     "miaoyan": {
       "primary": "productivity",
-      "secondary": []
-    },
-    "micro-sniff": {
-      "primary": "utilities",
       "secondary": []
     },
     "micro-snitch": {

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,24 +1,16 @@
 # Daily classification update
 
-Generated 2026-07-27
+Generated 2026-07-28
 
 ## Summary
 
-- 1 new casks classified
-- 1 classifications require manual review (confidence below 0.75)
+- 0 new casks classified
+- 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
-- 0 casks deprecated/disabled in Homebrew (pruned)
+- 1 casks deprecated/disabled in Homebrew (pruned)
 
-## New classifications
+## Deprecated/disabled (pruned)
 
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `airsync` | utilities | communication | 0.65 | Continuity-style tool syncing Android devices with macOS, primarily a system utility bridging device notifications/data. |
-
-## Manual review required
-
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `airsync` | utilities | communication | 0.65 | Continuity-style tool syncing Android devices with macOS, primarily a system utility bridging device notifications/data. |
+- `micro-sniff`


### PR DESCRIPTION
# Daily classification update

Generated 2026-07-28

## Summary

- 0 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 1 casks deprecated/disabled in Homebrew (pruned)

## Deprecated/disabled (pruned)

- `micro-sniff`
