### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-07-28",
-  "totalCasks": 3831,
+  "generatedDate": "2026-07-30",
+  "totalCasks": 3835,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -2631,6 +2631,12 @@
     "cmpxat": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "cmtrace-open": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "cmux": {
       "primary": "developerTools",
@@ -7791,6 +7797,18 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "luna-display": {
+      "primary": "utilities",
+      "secondary": [
+        "designGraphics"
+      ]
+    },
+    "luna-secondary": {
+      "primary": "utilities",
+      "secondary": [
+        "videoMedia"
+      ]
+    },
     "lunacy": {
       "primary": "designGraphics",
       "secondary": []
@@ -11861,6 +11879,12 @@
     "redis-insight": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "redot": {
+      "primary": "developerTools",
+      "secondary": [
+        "games"
+      ]
     },
     "refine": {
       "primary": "productivity",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,16 +1,27 @@
 # Daily classification update
 
-Generated 2026-07-28
+Generated 2026-07-30
 
 ## Summary
 
-- 0 new casks classified
-- 0 classifications require manual review (confidence below 0.75)
+- 4 new casks classified
+- 1 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
-- 1 casks deprecated/disabled in Homebrew (pruned)
+- 0 casks deprecated/disabled in Homebrew (pruned)
 
-## Deprecated/disabled (pruned)
+## New classifications
 
-- `micro-sniff`
+| token | primary | secondary | confidence | reason |
+|---|---|---|---|---|
+| `cmtrace-open` | developerTools | utilities | 0.70 | A log viewer for system administration/diagnostic logs, fitting developer/system tooling for IT admins. |
+| `luna-display` | utilities | designGraphics | 0.75 | Luna Display extends a Mac's screen wirelessly to an iPad, a system-level display utility. |
+| `luna-secondary` | utilities | videoMedia | 0.75 | Turns a Mac/iPad into a second display, a system-level display utility. |
+| `redot` | developerTools | games | 0.90 | Redot is a game engine (Godot fork) used for building games, fitting developer tools with a games-related secondary trait. |
+
+## Manual review required
+
+| token | primary | secondary | confidence | reason |
+|---|---|---|---|---|
+| `cmtrace-open` | developerTools | utilities | 0.70 | A log viewer for system administration/diagnostic logs, fitting developer/system tooling for IT admins. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -4537,6 +4537,13 @@
     "og_desc": "xattred - full-featured extended attribute editor, can also add quarantine xattrs Updated! xattred lets you inspect and edit all extended attributes (xattrs) associated with a file or folder,..."
   },
   {
+    "token": "cmtrace-open",
+    "homepage": "https://cmtraceopen.com/",
+    "title": "CMTrace Open: free CMTrace replacement for Windows logs",
+    "meta_desc": "Free, open-source log viewer for ConfigMgr/SCCM, Intune, and Autopilot logs. Auto-detects formats, tails in real time, and decodes Windows error codes.",
+    "og_desc": "Free, open-source log viewer for ConfigMgr/SCCM, Intune, and Autopilot logs. Auto-detects formats, tails in real time, and decodes Windows error codes."
+  },
+  {
     "token": "cmux",
     "homepage": "https://www.cmux.dev/",
     "title": "cmux - The terminal built for multitasking",
@@ -31529,6 +31536,20 @@
     "error": "HTTP 403"
   },
   {
+    "token": "luna-display",
+    "homepage": "https://astropad.com/product/lunadisplay/",
+    "title": "Luna Display | Turn your Mac or iPad into a second display",
+    "meta_desc": "The only hardware solution that turns any Mac or iPad into a wireless second display.",
+    "og_desc": "The only hardware solution that turns any Mac or iPad into a wireless second display."
+  },
+  {
+    "token": "luna-secondary",
+    "homepage": "https://astropad.com/product/lunadisplay/",
+    "title": "Luna Display | Turn your Mac or iPad into a second display",
+    "meta_desc": "The only hardware solution that turns any Mac or iPad into a wireless second display.",
+    "og_desc": "The only hardware solution that turns any Mac or iPad into a wireless second display."
+  },
+  {
     "token": "lunacy",
     "homepage": "https://icons8.com/lunacy",
     "title": "Lunacy - Free Graphic Design Software for Desktop: Download for Windows, Mac, Linux",
@@ -38847,6 +38868,13 @@
     "title": "GitHub - cmushroom/redis-pro: redis-pro redis 桌面管理工具 · GitHub",
     "meta_desc": "redis-pro redis 桌面管理工具. Contribute to cmushroom/redis-pro development by creating an account on GitHub.",
     "og_desc": "redis-pro redis 桌面管理工具. Contribute to cmushroom/redis-pro development by creating an account on GitHub."
+  },
+  {
+    "token": "redot",
+    "homepage": "https://redotengine.org/",
+    "title": "Redot Engine: Open source game engine for everyone",
+    "meta_desc": "",
+    "og_desc": ""
   },
   {
     "token": "redquits",


### PR DESCRIPTION
# Daily classification update

Generated 2026-07-30

## Summary

- 4 new casks classified
- 1 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `cmtrace-open` | developerTools | utilities | 0.70 | A log viewer for system administration/diagnostic logs, fitting developer/system tooling for IT admins. |
| `luna-display` | utilities | designGraphics | 0.75 | Luna Display extends a Mac's screen wirelessly to an iPad, a system-level display utility. |
| `luna-secondary` | utilities | videoMedia | 0.75 | Turns a Mac/iPad into a second display, a system-level display utility. |
| `redot` | developerTools | games | 0.90 | Redot is a game engine (Godot fork) used for building games, fitting developer tools with a games-related secondary trait. |

## Manual review required

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `cmtrace-open` | developerTools | utilities | 0.70 | A log viewer for system administration/diagnostic logs, fitting developer/system tooling for IT admins. |
