### PR TITLE
fix: Mine full UTC timestamps for cask added dates

### DIFF
--- a/scripts/mine_added_dates.py
+++ b/scripts/mine_added_dates.py
@@ -127,7 +127,9 @@ def main() -> int:
     payload = {
         "version": 1,
         # Timestamp, not date: lets clients accept a second release cut the same day.
-        "generatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generatedDate": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
         "totalCasks": len(added),
         "tokenAddedDates": dict(sorted(added.items())),
     }

--- a/scripts/mine_added_dates.py
+++ b/scripts/mine_added_dates.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-"""Mine each cask's earliest addition date from Homebrew's git history."""
+"""Mine each cask's earliest addition timestamp (UTC) from Homebrew's git history."""
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 import tempfile
-from datetime import date
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -16,7 +17,9 @@ OUTPUT_PATH = REPO_ROOT / "added_dates.json"
 TAP_URL = "https://github.com/Homebrew/homebrew-cask"
 GIT_EXECUTABLE = "/usr/bin/git"
 
-DATE_LINE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+# Full UTC timestamps so same-day adds keep their true merge order; ISO-8601
+# Zulu strings compare lexicographically, so consumers keep plain string sorts.
+DATE_LINE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
 def clone_tap(dest: str) -> Path:
@@ -53,12 +56,13 @@ def mine(repo: Path) -> dict[str, str]:
             # Follow the default branch and compare merge commits with their
             # first parent. Feature-branch commit dates can predate the merge
             # by days, while the first-parent commit records when they landed.
-            "--date=short", "--format=%cd",
+            "--date=format-local:%Y-%m-%dT%H:%M:%SZ", "--format=%cd",
             "--", "Casks/",
         ],
         check=True,
         capture_output=True,
         text=True,
+        env=os.environ | {"TZ": "UTC"},
     ).stdout
     return parse_log(log)
 
@@ -122,7 +126,8 @@ def main() -> int:
 
     payload = {
         "version": 1,
-        "generatedDate": date.today().isoformat(),
+        # Timestamp, not date: lets clients accept a second release cut the same day.
+        "generatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "totalCasks": len(added),
         "tokenAddedDates": dict(sorted(added.items())),
     }

--- a/tests/test_mine_added_dates.py
+++ b/tests/test_mine_added_dates.py
@@ -131,6 +131,33 @@ def test_mines_default_branch_landing_date_for_delayed_merge(tmp_path):
     assert mine(repo)["openwhispr"] == "2026-07-23T09:27:47Z"
 
 
+def test_non_utc_committer_dates_normalize_to_utc(tmp_path):
+    repo = tmp_path / "homebrew-cask"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+
+    cask = repo / "Casks" / "t" / "tz-app.rb"
+    cask.parent.mkdir(parents=True)
+    cask.write_text('cask "tz-app" do\nend\n', encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", str(cask)], check=True)
+    env = os.environ | {
+        "GIT_AUTHOR_DATE": "2026-07-30T09:00:00+09:00",
+        "GIT_COMMITTER_DATE": "2026-07-30T09:00:00+09:00",
+    }
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "Add tz cask"],
+        check=True,
+        env=env,
+    )
+
+    assert mine(repo)["tz-app"] == "2026-07-30T00:00:00Z"
+
+
 def test_coverage_check_catches_an_active_cask_without_a_date(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "mine_added_dates.current_cask_tokens",

--- a/tests/test_mine_added_dates.py
+++ b/tests/test_mine_added_dates.py
@@ -9,15 +9,15 @@ from mine_added_dates import current_cask_tokens, mine, parse_log, validate_curr
 
 LOG = "\n".join([
     # Newest first, like git log. The 2023 sharding move re-added iterm2.
-    "2023-06-01",
+    "2023-06-01T08:15:00Z",
     "",
     "A\tCasks/i/iterm2.rb",
     "A\tCasks/f/firefox.rb",
-    "2020-03-15",
+    "2020-03-15T12:30:45Z",
     "",
     "A\tCasks/newapp.rb",
     "M\tCasks/other.rb",
-    "2012-12-19",
+    "2012-12-19T23:59:59Z",
     "",
     "A\tCasks/iterm2.rb",
     "A\tCasks/README.md",
@@ -25,13 +25,13 @@ LOG = "\n".join([
 
 
 def test_earliest_add_wins_across_sharding_move():
-    assert parse_log(LOG)["iterm2"] == "2012-12-19"
+    assert parse_log(LOG)["iterm2"] == "2012-12-19T23:59:59Z"
 
 
 def test_single_add_keeps_its_date():
     result = parse_log(LOG)
-    assert result["newapp"] == "2020-03-15"
-    assert result["firefox"] == "2023-06-01"
+    assert result["newapp"] == "2020-03-15T12:30:45Z"
+    assert result["firefox"] == "2023-06-01T08:15:00Z"
 
 
 def test_non_ruby_and_modified_files_are_ignored():
@@ -74,7 +74,7 @@ def test_mines_cask_that_has_no_category(tmp_path):
     category_tokens: set[str] = set()
     assert token not in category_tokens
     assert current_cask_tokens(repo) == {token}
-    assert added[token] == "2026-07-23"
+    assert added[token] == "2026-07-23T12:00:00Z"
     assert validate_current_cask_coverage(repo, added) == set()
 
 
@@ -128,7 +128,7 @@ def test_mines_default_branch_landing_date_for_delayed_merge(tmp_path):
         env=merge_env,
     )
 
-    assert mine(repo)["openwhispr"] == "2026-07-23"
+    assert mine(repo)["openwhispr"] == "2026-07-23T09:27:47Z"
 
 
 def test_coverage_check_catches_an_active_cask_without_a_date(tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

All casks merged the same day carried the same `YYYY-MM-DD` value, so CaskHub's newest-first sort saw ties and fell back to catalog (alphabetical) order — e.g. today's shelf showed CMTrace Open first even though it merged at 05:14 UTC while Tight Studio merged at 23:06 UTC.

## What

- `git log` now emits `--date=format-local:%Y-%m-%dT%H:%M:%SZ` with `TZ=UTC`, so values are full ISO-8601 Zulu timestamps of the first-parent (merge) committer date.
- ISO-8601 UTC strings compare lexicographically = chronologically: CaskHub's cutoff check (`value >= "2026-07-01"`), newest/oldest sorts, and the `"9999"` unmined default all keep working with zero app changes; schema stays v1.
- `generatedDate` is now a timestamp too, so the app's `remote.generatedDate > current` check accepts a second release cut on the same day.

## Tests

Fixture and git-based tests updated to timestamp expectations; `test_mine_added_dates.py` + `test_workflow_contracts.py`: 10 passed.