### PR TITLE
fix: Release fresh icon manifests same-day and disarm stale auto-merge

### DIFF
--- a/.github/workflows/classify-new-casks.yml
+++ b/.github/workflows/classify-new-casks.yml
@@ -82,3 +82,18 @@ jobs:
           if [ "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]; then
             gh pr merge --auto --squash "$PR"
           fi
+
+      # A previous run may have armed auto-merge before this batch turned
+      # low-confidence; without disarming, the PR could merge unreviewed.
+      - name: Disable auto-merge while review is pending
+        if: >-
+          env.DRY_RUN != 'true' &&
+          steps.pr.outputs.pull-request-number != '' &&
+          steps.classify.outputs.review_required == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CLASSIFY_BOT_TOKEN || github.token }}
+          PR: ${{ steps.pr.outputs.pull-request-number }}
+        run: |
+          if [ "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+            gh pr merge --disable-auto "$PR"
+          fi

--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: extract-icons
@@ -51,3 +52,10 @@ jobs:
           else
             python3 scripts/extract_icons.py --publish --limit "$LIMIT"
           fi
+
+      # The daily release (14:47 UTC) predates this run, and iconTokens is
+      # stamped at release time - without this, today's icons ship tomorrow.
+      - name: Cut data release with the fresh icon manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yml

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -25,6 +25,20 @@ def test_auto_merge_checks_null_as_a_boolean():
     assert "--jq '.autoMergeRequest')\" = \"null\"" not in classification
 
 
+def test_pending_review_disarms_previously_enabled_auto_merge():
+    classification = _workflow("classify-new-casks.yml")
+
+    assert "review_required == 'true'" in classification
+    assert "gh pr merge --disable-auto" in classification
+
+
+def test_icon_publication_cuts_a_release_for_the_fresh_manifest():
+    icons = _workflow("extract-icons.yml")
+
+    assert "actions: write" in icons
+    assert "gh workflow run release.yml" in icons
+
+
 def test_pr_hygiene_can_assign_pull_requests():
     hygiene = _workflow("pr-hygiene.yml")
 


### PR DESCRIPTION
## Why

Two cadence/safety gaps in the pipeline:

1. **Icons always ship a day late.** `extract-icons` runs daily at 15:43 UTC, but `release.yml` (which stamps the `iconTokens` manifest from the icons branch) runs at 14:47 UTC — before extraction. PNGs published today only become visible to the app in tomorrow's release.
2. **Stale auto-merge can merge unreviewed classifications.** A high-confidence run arms auto-merge on the rolling PR; if a later run adds low-confidence casks before checks complete, the enable step is skipped but the armed request survives — the PR can merge without the required manual review.

## What

- `extract-icons.yml`: dispatches `release.yml` after publication (`actions: write` added), so the manifest is re-stamped with today's icons the same day.
- `classify-new-casks.yml`: new step disarms auto-merge (`gh pr merge --disable-auto`) whenever `review_required` is true.
- Contract tests for both in `test_workflow_contracts.py` (5 passed).
