### PR TITLE
ci: Snapshot repo traffic stats weekly

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -1,0 +1,17 @@
+name: Repo Traffic Stats
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jgehrcke/github-repo-stats@306db38ad131cab2aa5f2cd3062bf6f8aa78c1aa # v1.4.2
+        with:
+          ghtoken: ${{ github.token }}


### PR DESCRIPTION
## Summary
Adds a weekly scheduled workflow using [`jgehrcke/github-repo-stats`](https://github.com/jgehrcke/github-repo-stats) to snapshot it before it expires.

- Runs Mondays 03:00 UTC + manual `workflow_dispatch`
- Appends deduplicated CSV snapshots and an HTML/markdown report to a dedicated `github-repo-stats` data branch