### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-07-30",
-  "totalCasks": 3835,
+  "generatedDate": "2026-07-31",
+  "totalCasks": 3838,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -10725,6 +10725,12 @@
       "primary": "designGraphics",
       "secondary": []
     },
+    "phosphene": {
+      "primary": "screensaverWallpaper",
+      "secondary": [
+        "videoMedia"
+      ]
+    },
     "photoninja": {
       "primary": "designGraphics",
       "secondary": []
@@ -13359,6 +13365,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "spacejump": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "spacelauncher": {
       "primary": "utilities",
       "secondary": [
@@ -14507,6 +14519,10 @@
     },
     "tigervnc": {
       "primary": "utilities",
+      "secondary": []
+    },
+    "tight-studio": {
+      "primary": "videoMedia",
       "secondary": []
     },
     "tikz-editor": {

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,11 +1,11 @@
 # Daily classification update
 
-Generated 2026-07-30
+Generated 2026-07-31
 
 ## Summary
 
-- 4 new casks classified
-- 1 classifications require manual review (confidence below 0.75)
+- 3 new casks classified
+- 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
@@ -15,13 +15,6 @@ Generated 2026-07-30
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `cmtrace-open` | developerTools | utilities | 0.70 | A log viewer for system administration/diagnostic logs, fitting developer/system tooling for IT admins. |
-| `luna-display` | utilities | designGraphics | 0.75 | Luna Display extends a Mac's screen wirelessly to an iPad, a system-level display utility. |
-| `luna-secondary` | utilities | videoMedia | 0.75 | Turns a Mac/iPad into a second display, a system-level display utility. |
-| `redot` | developerTools | games | 0.90 | Redot is a game engine (Godot fork) used for building games, fitting developer tools with a games-related secondary trait. |
-
-## Manual review required
-
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `cmtrace-open` | developerTools | utilities | 0.70 | A log viewer for system administration/diagnostic logs, fitting developer/system tooling for IT admins. |
+| `phosphene` | screensaverWallpaper | videoMedia | 0.95 | App sets custom video wallpapers for desktop and lock screen on macOS. |
+| `spacejump` | menuBar | utilities | 0.85 | A menu bar utility for naming and switching macOS desktop Spaces. |
+| `tight-studio` | videoMedia | - | 0.90 | Screen recorder and video editor for producing videos. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -36883,6 +36883,13 @@
     "og_desc": ""
   },
   {
+    "token": "phosphene",
+    "homepage": "https://kagerou.glass/phosphene/",
+    "title": "Phosphene - video wallpapers for macOS",
+    "meta_desc": "I reverse engineered Apple's private WallpaperExtensionKit so any video can be your desktop and lock screen wallpaper. Free, open source, MIT.",
+    "og_desc": "I reverse engineered Apple's video wallpapers. Any video, desktop and lock screen, through Apple's own extension path. Free, open source, MIT."
+  },
+  {
     "token": "photoninja",
     "homepage": "https://www.picturecode.com/index.php",
     "title": "PictureCode home page: Photo Ninja",
@@ -41596,6 +41603,13 @@
     "og_desc": "macOS space indicator. Contribute to dshnkao/SpaceId development by creating an account on GitHub."
   },
   {
+    "token": "spacejump",
+    "homepage": "https://getspacejump.com/",
+    "title": "SpaceJump - Rename macOS Desktops & Spaces",
+    "meta_desc": "Name your Mac desktops. See Space names in menu bar. Switch & jump back instantly. The missing macOS feature. Try free for 14 days.",
+    "og_desc": "Name your Mac desktops. See Space names in menu bar. Switch & jump back instantly. Try free for 14 days."
+  },
+  {
     "token": "spacelauncher",
     "homepage": "https://spacelauncherapp.com/",
     "title": "SpaceLauncher - App Launcher and Switcher for Mac",
@@ -43793,6 +43807,13 @@
     "title": "TigerVNC",
     "meta_desc": "",
     "og_desc": ""
+  },
+  {
+    "token": "tight-studio",
+    "homepage": "https://tight.studio/",
+    "title": "Tight Studio - Free screen recorder to make stunning videos",
+    "meta_desc": "Your work deserves a better video. Screen record and produce stunning demos, tutorials, and presentations in minutes.",
+    "og_desc": "Your work deserves a better video. Screen record and produce stunning demos, tutorials, and presentations in minutes."
   },
   {
     "token": "tikz-editor",


### PR DESCRIPTION
# Daily classification update

Generated 2026-07-31

## Summary

- 3 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `phosphene` | screensaverWallpaper | videoMedia | 0.95 | App sets custom video wallpapers for desktop and lock screen on macOS. |
| `spacejump` | menuBar | utilities | 0.85 | A menu bar utility for naming and switching macOS desktop Spaces. |
| `tight-studio` | videoMedia | - | 0.90 | Screen recorder and video editor for producing videos. |
