### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-01",
-  "totalCasks": 3842,
+  "generatedDate": "2026-08-02",
+  "totalCasks": 3843,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -12674,6 +12674,12 @@
     "send-anywhere": {
       "primary": "utilities",
       "secondary": []
+    },
+    "send-to-kindle": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
     },
     "sensei": {
       "primary": "utilities",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,10 +1,10 @@
 # Daily classification update
 
-Generated 2026-08-01
+Generated 2026-08-02
 
 ## Summary
 
-- 4 new casks classified
+- 1 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
@@ -15,7 +15,4 @@ Generated 2026-08-01
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `degr` | screensaverWallpaper | - | 0.97 | Explicitly described as a temperature and clock screensaver. |
-| `lm-studio-bionic` | productivity | ai, developerTools | 0.75 | LM Studio Bionic is an AI agent for creating documents and code using local or open models, blending productivity and coding assistance. |
-| `mend` | securityPrivacy | developerTools | 0.85 | CLI tool for application security scanning, relevant to developers but primarily a security tool. |
-| `orbit` | communication | productivity | 0.85 | A native Gmail/Google Workspace client for managing multiple accounts, primarily an email/communication tool. |
+| `send-to-kindle` | utilities | productivity | 0.75 | A macOS tool for transferring documents to Kindle devices, which is a system-level file transfer utility. |


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-02

## Summary

- 1 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `send-to-kindle` | utilities | productivity | 0.75 | A macOS tool for transferring documents to Kindle devices, which is a system-level file transfer utility. |
