### PR TITLE
docs: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: 🐛 Bug Report
+about: A pipeline script crashes, misbehaves, or produces wrong output
+labels: bug
+---
+
+<!--
+Wrong category, icon, or added date for a specific cask? Use the
+"Data Correction" template instead - that is curated data, not a code bug.
+
+Reports missing the information below may be closed without triage.
+-->
+
+### Checklist
+
+- [ ] I searched [existing issues](https://github.com/alielsokary/CaskFlow/issues?q=is%3Aissue) and found no duplicate
+
+### Description
+
+<!-- A clear and concise description of the bug. -->
+
+### Command Run
+
+```bash
+# The exact command, e.g.:
+# LLM_PROVIDER=mock python scripts/classify_new_casks.py --dry-run
+```
+
+### Expected vs Actual Behavior
+
+<!-- What you expected, and what happened instead. Paste relevant output. -->
+
+### Environment
+
+- **OS**:
+- **Python** (`python3 --version`):
+- **LLM provider** (anthropic / openai / groq / cloudflare / mock):

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Security vulnerability
+    url: https://github.com/alielsokary/CaskFlow/security/advisories/new
+    about: Report privately - never through public issues. See SECURITY.md.
+  - name: 🖥️ CaskHub app problem
+    url: https://github.com/alielsokary/CaskHub/issues/new/choose
+    about: Bugs in the macOS app itself belong in the CaskHub repository.
+  - name: 🍺 Missing or broken cask
+    url: https://github.com/Homebrew/homebrew-cask/issues
+    about: CaskFlow classifies Homebrew's catalog - cask availability issues belong upstream.

--- a/.github/ISSUE_TEMPLATE/correction.md
+++ b/.github/ISSUE_TEMPLATE/correction.md
@@ -1,0 +1,31 @@
+---
+name: 🗂️ Data Correction
+about: A cask has the wrong category, icon, or added date
+labels: data-correction
+---
+
+<!--
+Prefer a pull request? Category fixes are applied through
+data/category_corrections.json - see CONTRIBUTING.md and
+docs/CLASSIFICATION_GUIDE.md for the schema and boundary rules.
+This issue form is fine too; a maintainer will turn it into a correction.
+-->
+
+### Cask Token
+
+<!-- e.g. visual-studio-code (the Homebrew token, not the display name) -->
+
+### What Is Wrong
+
+- [ ] Category
+- [ ] Icon
+- [ ] Added date
+
+### Current vs Expected
+
+<!-- e.g. "currently developer-tools, should be productivity" -->
+
+### Evidence
+
+<!-- App homepage, vendor description, App Store listing - anything that
+     supports the expected classification. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,21 @@
+---
+name: ✨ Feature Request
+about: Suggest an improvement to the pipeline or its published data
+labels: enhancement
+---
+
+### Checklist
+
+- [ ] I searched [existing issues](https://github.com/alielsokary/CaskFlow/issues?q=is%3Aissue) and found no duplicate
+
+### Problem / Use Case
+
+<!-- What problem does this solve? What are you trying to do? -->
+
+### Proposed Solution
+
+<!-- How should it work? -->
+
+### Alternatives
+
+<!-- Optional: other approaches you considered. -->


### PR DESCRIPTION
## Summary

Adds `.github/ISSUE_TEMPLATE/` with three markdown templates plus chooser config:

- **Bug report** (`bug`): pipeline script bugs - command run, expected vs actual, environment (OS / Python / LLM provider). Header comment redirects per-cask data problems to the correction template.
- **Data correction** (`data-correction`, new label): wrong category / icon / added date - cask token, current vs expected, evidence. Header points contributors at the `data/category_corrections.json` PR path documented in CONTRIBUTING.md.
- **Feature request** (`enhancement`).
- **config.yml**: blank issues disabled; contact links route security reports to the private advisory form, app bugs to CaskHub, and cask availability issues to homebrew-cask.

This is the receiving end of CaskHub's issue chooser, which links cask-data corrections here (CaskHub #131).

## Verification

- `pytest tests/test_style_standards.py` passes with the new files tracked (ASCII punctuation only).
- `bug`, `enhancement`, `data-correction` labels all exist on the repo.