### PR TITLE
ci: Adopt develop as the integration branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 
 <!-- List the commands or checks you ran. -->
 
+- [ ] Base branch is `develop` (not `master`)
 - [ ] Tests pass locally
 - [ ] Documentation reflects behavior or schema changes
 - [ ] CaskHub consumer impact was checked when applicable

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,49 @@
+name: Sync develop with master
+
+# Back-merge automation: every push to master opens (or reuses) a
+# "chore: master to develop" PR so develop never drifts behind the daily
+# classification commits and releases that land on master.
+#
+# The PR auto-merges with a merge commit (never squash: squashing rewrites
+# the shared history and makes every later back-merge conflict).
+#
+# Requires the repo setting "Allow GitHub Actions to create and approve
+# pull requests" (Settings > Actions > General).
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Open auto-merging PR master -> develop
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          existing=$(gh pr list --base develop --head master --state open --json number --jq '.[].number')
+          if [ -n "$existing" ]; then
+            echo "Open master->develop PR #$existing already exists; new commits land on it automatically."
+            exit 0
+          fi
+          if ! out=$(gh pr create \
+            --base develop \
+            --head master \
+            --title "chore: master to develop" \
+            --body "Automated back-merge to keep develop in sync with master." \
+            --assignee alielsokary 2>&1); then
+            echo "$out"
+            # only "develop already has everything" is a legitimate no-op
+            echo "$out" | grep -qi "no commits between" && exit 0
+            exit 1
+          fi
+          echo "$out"
+          num=$(gh pr list --base develop --head master --state open --json number --jq '.[0].number')
+          gh pr merge --auto --merge "$num" || echo "Auto-merge unavailable; merge PR #$num manually."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,16 @@ python scripts/apply_corrections.py
 
 Use `--all` only after the non-high-confidence entries have been reviewed. The tool rejects unknown categories, stale `was` values, secondary-only traits used as primaries, duplicate categories, and more than two secondary categories.
 
+## Branch model
+
+Pull requests **must** target the `develop` branch, not `master`.
+
+`master` is production: the daily classification bot commits to it and releases publish from it. It receives the automated back-merge and promotion merges only.
+
+Exception: automated PRs (daily classification, master-to-develop sync) are managed by workflows and target their own branches.
+
+Name branches `type/kebab-case-description`, for example `fix/icon-release-ordering`.
+
 ## Pull requests
 
 PR titles follow the semantic form `<type>(optional-scope): description`. Allowed types are `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, and `test`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/alielsokary/CaskFlow/actions/workflows/tests.yml/badge.svg)](https://github.com/alielsokary/CaskFlow/actions/workflows/tests.yml)
 [![Codacy](https://app.codacy.com/project/badge/Grade/825c27dd6a6141afb36aa99fe880239f)](https://app.codacy.com/gh/alielsokary/CaskFlow/dashboard)
-[![codecov](https://codecov.io/gh/alielsokary/CaskFlow/branch/master/graph/badge.svg)](https://codecov.io/gh/alielsokary/CaskFlow)
+[![codecov](https://codecov.io/gh/alielsokary/CaskFlow/branch/develop/graph/badge.svg)](https://codecov.io/gh/alielsokary/CaskFlow)
 [![Latest release](https://img.shields.io/github/v/release/alielsokary/CaskFlow)](https://github.com/alielsokary/CaskFlow/releases/latest)
 [![License](https://img.shields.io/github/license/alielsokary/CaskFlow)](LICENSE)
 
@@ -69,7 +69,7 @@ Real classification supports `anthropic`, `openai`, `groq`, and `cloudflare`; ch
 
 ## Contributing
 
-Bug reports, taxonomy corrections, tests, documentation improvements, and pipeline hardening are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), which explains local verification, category correction evidence, and the required semantic PR title format.
+Bug reports, taxonomy corrections, tests, documentation improvements, and pipeline hardening are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), which explains local verification, category correction evidence, and the required semantic PR title format. Pull requests target the `develop` branch.
 
 Examples: `fix(classifier): Handle malformed output`, `docs: Clarify category boundaries`, or `chore: Daily cask classification update`.
 

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -39,6 +39,15 @@ def test_icon_publication_cuts_a_release_for_the_fresh_manifest():
     assert "gh workflow run release.yml" in icons
 
 
+def test_back_merge_targets_develop_with_a_merge_commit():
+    sync = _workflow("sync-develop.yml")
+
+    assert "--base develop" in sync
+    assert "--head master" in sync
+    assert "gh pr merge --auto --merge" in sync
+    assert "--squash" not in sync
+
+
 def test_pr_hygiene_can_assign_pull_requests():
     hygiene = _workflow("pr-hygiene.yml")
 


### PR DESCRIPTION
## Summary

Wires the repo for the new `develop` integration branch:

- **New `sync-develop.yml`**: every push to `master` (daily classification commits, releases, promotions) opens or reuses a `chore: master to develop` back-merge PR and enables auto-merge with a **merge commit** - never squash, which would rewrite shared history and make every later back-merge conflict. Without this, develop drifts behind master daily.
- **`tests.yml`**: pushes to `develop` now run the suite and upload coverage (PR runs were already covered by the bare `pull_request` trigger).
- **`test_workflow_contracts.py`**: new contract test pins the back-merge base/head and the merge-commit strategy.
- **CONTRIBUTING.md**: new Branch model section - PRs must target `develop`; `master` is production (bot commits + releases); branch naming convention.
- **PR template**: base-branch checkbox.
- **README**: codecov badge tracks `develop`; Contributing section names the target branch.

Unchanged on purpose: classification bot, `release.yml`, `extract-icons.yml`, and the default branch all stay on `master` - the data pipeline must keep flowing there for daily releases.

## Why this PR targets master

The sync workflow only fires from the default branch, and GitHub reads community files from it. Landing this on `master` bootstraps the model; the first back-merge PR it triggers will carry it to `develop`.

## Verification

- Full suite: 111 passed (includes the new contract test and style standards).
- Repo settings verified: auto-merge enabled, merge commits allowed, Actions may create PRs.
- `gh pr merge --auto --merge` falls back to a manual-merge log line if auto-merge is ever unavailable.