### PR TITLE
ci: Author back-merge PRs with the bot PAT so auto-merge completes

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -7,8 +7,9 @@ name: Sync develop with master
 # The PR auto-merges with a merge commit (never squash: squashing rewrites
 # the shared history and makes every later back-merge conflict).
 #
-# Requires the repo setting "Allow GitHub Actions to create and approve
-# pull requests" (Settings > Actions > General).
+# Uses CLASSIFY_BOT_TOKEN (same PAT as the classification bot) so the PR
+# is authored by the owner: bot-authored PRs need manual workflow approval,
+# which blocks the required Tests check and stalls auto-merge forever.
 on:
   push:
     branches: [master]
@@ -25,7 +26,7 @@ jobs:
 
       - name: Open auto-merging PR master -> develop
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CLASSIFY_BOT_TOKEN || github.token }}
         run: |
           set -euo pipefail
           existing=$(gh pr list --base develop --head master --state open --json number --jq '.[].number')

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -46,6 +46,8 @@ def test_back_merge_targets_develop_with_a_merge_commit():
     assert "--head master" in sync
     assert "gh pr merge --auto --merge" in sync
     assert "--squash" not in sync
+    # PAT author: bot-authored PRs stall on manual workflow approval
+    assert "secrets.CLASSIFY_BOT_TOKEN" in sync
 
 
 def test_pr_hygiene_can_assign_pull_requests():


### PR DESCRIPTION
## Summary

The first back-merge PR (#64) stalled: it was authored by `github-actions[bot]` (default `github.token`), and GitHub holds bot-authored PRs' workflow runs for manual approval. The required Tests check never ran, so auto-merge never completed.

Fix: create the PR with `secrets.CLASSIFY_BOT_TOKEN || github.token` - the same PAT pattern the classification bot already uses. PRs are then authored by the repo owner: no approval gate, checks run, auto-merge completes.

Contract test extended to pin the token choice.

## Verification

- Full suite passes locally (111 tests, including the extended contract test).
- Same mechanism verified daily by `classify-new-casks.yml` auto-merge.

Note: #64 itself still needs one manual touch (approve workflows or merge it) since it predates this fix. Targets master because the workflow fires from the default branch.