### PR TITLE
docs: Add projects-using and attribution sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Latest release](https://img.shields.io/github/v/release/alielsokary/CaskFlow)](https://github.com/alielsokary/CaskFlow/releases/latest)
 [![License](https://img.shields.io/github/license/alielsokary/CaskFlow)](LICENSE)
 
-<img width="1700" height="500" alt="CaskFlow banner" src="https://github.com/user-attachments/assets/a9c5d9cc-16ff-401c-b919-29daa5e520ca" />
+<img width="1700" height="500" alt="caskflow-banner" src="https://github.com/user-attachments/assets/6ca8ac54-e5b8-443a-a391-4e32ad2e2b44" />
 
 CaskFlow turns the live Homebrew cask catalog into reviewed, release-ready metadata for [CaskHub](https://github.com/alielsokary/CaskHub). It classifies applications, tracks when casks were added, extracts vendor icons safely, and publishes versioned assets that CaskHub can consume with a bundled fallback.
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,22 @@ Real classification supports `anthropic`, `openai`, `groq`, and `cloudflare`; ch
 - [`data/`](data) holds generated reports, caches, and reviewed correction input; it is not the canonical category source.
 - [`.github/workflows/`](.github/workflows) contains classification, icon, release, and verification automation.
 
+## Projects using CaskFlow
+
+| Project | Description | Categories | Added&nbsp;Dates | Icons |
+|---|---|:---:|:---:|:---:|
+| [CaskHub](https://github.com/alielsokary/CaskHub) | Native macOS app for discovering, installing, and managing Homebrew casks | ✅ | ✅ | ✅ |
+| [*Add&nbsp;yours*](https://github.com/alielsokary/CaskFlow/edit/develop/README.md) | Using CaskFlow data in your project? Add it to this table | - | - | - |
+
+## Attribution
+
+CaskFlow is [MIT licensed](LICENSE), so no attribution is required beyond the license terms. If your project consumes CaskFlow data (categories, added dates, or icons), a visible credit with a link back is very much appreciated, for example:
+
+> Cask metadata powered by [CaskFlow](https://github.com/alielsokary/CaskFlow)
+
 ## Contributing
 
 Bug reports, taxonomy corrections, tests, documentation improvements, and pipeline hardening are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), which explains local verification, category correction evidence, and the required semantic PR title format. Pull requests target the `develop` branch.
-
-Examples: `fix(classifier): Handle malformed output`, `docs: Clarify category boundaries`, or `chore: Daily cask classification update`.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds a **Projects using CaskFlow** table to the README, seeded with CaskHub, with a standing invitation for downstream projects to add themselves via PR.
- Adds an **Attribution** section: requests a visible credit with a link back and provides a ready-to-copy example line.

## Notes

A matching Acknowledgements section crediting CaskFlow is being added to the CaskHub README in a separate PR.