### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-04",
-  "totalCasks": 3851,
+  "generatedDate": "2026-08-05",
+  "totalCasks": 3856,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -4372,6 +4372,12 @@
       "primary": "productivity",
       "secondary": []
     },
+    "esphome-device-builder": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "espresso": {
       "primary": "developerTools",
       "secondary": []
@@ -7166,6 +7172,12 @@
         "ai"
       ]
     },
+    "kirocrew": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "kitlangton-hex": {
       "primary": "productivity",
       "secondary": []
@@ -7262,6 +7274,12 @@
     "kopiaui": {
       "primary": "utilities",
       "secondary": []
+    },
+    "koreader": {
+      "primary": "productivity",
+      "secondary": [
+        "utilities"
+      ]
     },
     "kotlin-lsp": {
       "primary": "developerTools",
@@ -8403,6 +8421,13 @@
     "meetingbar": {
       "primary": "menuBar",
       "secondary": []
+    },
+    "meetingrecorder": {
+      "primary": "videoMedia",
+      "secondary": [
+        "productivity",
+        "ai"
+      ]
     },
     "meetmic": {
       "primary": "productivity",
@@ -14249,6 +14274,12 @@
     "tau": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "tauritavern": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "tdr-kotelnikov": {
       "primary": "audioMusic",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,11 +1,11 @@
 # Daily classification update
 
-Generated 2026-08-04
+Generated 2026-08-05
 
 ## Summary
 
-- 6 new casks classified
-- 0 classifications require manual review (confidence below 0.75)
+- 5 new casks classified
+- 2 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
@@ -15,9 +15,15 @@ Generated 2026-08-04
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `android-cli` | developerTools | ai | 0.85 | CLI tool for Android app development, enhanced with AI agent support. |
-| `diversion` | developerTools | cloudStorage | 0.85 | A cloud-native version control CLI is a developer tool similar to Git/Perforce alternatives. |
-| `switchy` | utilities | menuBar | 0.80 | A system utility for switching Bluetooth peripherals between Macs, likely accessed via a menu bar icon. |
-| `tickernotch` | menuBar | utilities | 0.85 | App lives in the notch/menu bar showing tickers, weather, and news widgets. |
-| `work-louder-input` | utilities | - | 0.75 | A keyboard configurator app for hardware devices is a system utility for peripheral configuration. |
-| `zcode` | developerTools | ai | 0.85 | ZCode is an AI-powered coding harness/IDE-like environment for planning, coding, reviewing, and deploying software. |
+| `esphome-device-builder` | developerTools | utilities | 0.75 | A configuration/build tool for ESPHome IoT device firmware, closest to developer/embedded tooling. |
+| `kirocrew` | developerTools | ai | 0.80 | AI-powered multi-agent development workspace tool for developers. |
+| `koreader` | productivity | utilities | 0.70 | KOReader is a document/e-book viewer app, fitting productivity with a utility trait. |
+| `meetingrecorder` | videoMedia | productivity, ai | 0.75 | Records meeting audio/system sound with AI transcription features, blending media capture with productivity. |
+| `tauritavern` | productivity | ai | 0.70 | Native client for SillyTavern, an AI chat/roleplay frontend, so it's an AI-powered chat productivity app. |
+
+## Manual review required
+
+| token | primary | secondary | confidence | reason |
+|---|---|---|---|---|
+| `koreader` | productivity | utilities | 0.70 | KOReader is a document/e-book viewer app, fitting productivity with a utility trait. |
+| `tauritavern` | productivity | ai | 0.70 | Native client for SillyTavern, an AI chat/roleplay frontend, so it's an AI-powered chat productivity app. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -7550,6 +7550,13 @@
     "og_desc": ""
   },
   {
+    "token": "esphome-device-builder",
+    "homepage": "https://desktop.esphome.io/",
+    "title": "ESPHome Device Builder",
+    "meta_desc": "",
+    "og_desc": ""
+  },
+  {
     "token": "espresso",
     "homepage": "https://espressoapp.com/",
     "title": "Espresso - The Web Editor for Mac",
@@ -30448,6 +30455,13 @@
     "og_desc": "Command-line interface for Kiro - build, test, and deploy from anywhere"
   },
   {
+    "token": "kirocrew",
+    "homepage": "https://kiro.dev/docs/crew/",
+    "title": "Quick start - Crew - Docs - Kiro",
+    "meta_desc": "Get Crew running on your machine in five minutes - install, configure, and open the dashboard.",
+    "og_desc": "Get Crew running on your machine in five minutes - install, configure, and open the dashboard."
+  },
+  {
     "token": "kitlangton-hex",
     "homepage": "https://hex.kitlangton.com/",
     "title": "HEX",
@@ -30610,6 +30624,13 @@
     "title": "kopia-svg",
     "meta_desc": "Fast and Secure Open-Source Backup Software for Windows, Mac, and Linux",
     "og_desc": "Fast and Secure Open-Source Backup Software for Windows, Mac, and Linux"
+  },
+  {
+    "token": "koreader",
+    "homepage": "https://koreader.rocks/",
+    "title": "KOReader",
+    "meta_desc": "",
+    "og_desc": ""
   },
   {
     "token": "kotlin-lsp",
@@ -32595,6 +32616,13 @@
     "title": "GitHub - leits/MeetingBar: 🇺🇦 Your meetings at your fingertips in the macOS menu bar · GitHub",
     "meta_desc": "🇺🇦 Your meetings at your fingertips in the macOS menu bar  - GitHub - leits/MeetingBar: 🇺🇦 Your meetings at your fingertips in the macOS menu bar",
     "og_desc": "🇺🇦 Your meetings at your fingertips in the macOS menu bar  - leits/MeetingBar"
+  },
+  {
+    "token": "meetingrecorder",
+    "homepage": "https://meetingsrecorder.com/",
+    "title": "Meeting Recorder for Mac - Record Any Call, No Bots",
+    "meta_desc": "MeetingRecorder is a free Mac meeting recorder that captures any call - Zoom, Teams, Meet or any app - with no bot in the room. Recordings stay on your Mac, with one-click AI transcription and summaries.",
+    "og_desc": "MeetingRecorder is a free Mac meeting recorder that captures any call - Zoom, Teams, Meet or any app - with no bot in the room. Recordings stay on your Mac, with one-click AI transcription and summaries."
   },
   {
     "token": "mega",
@@ -43183,6 +43211,13 @@
     "title": "TAU - Tuning and Analysis Utilities -",
     "meta_desc": "Analysis of high performance\ncomputing. Designing profiling and tracing tool for scientific computing.",
     "og_desc": ""
+  },
+  {
+    "token": "tauritavern",
+    "homepage": "https://tauritavern.github.io/",
+    "title": "TauriTavern",
+    "meta_desc": "TauriTavern 文档站：围绕 Tauri v2、Rust 后端与 SillyTavern 1.18.0 前端兼容的工程文档。",
+    "og_desc": "TauriTavern 的架构、API 与开发文档站点。"
   },
   {
     "token": "tdr-kotelnikov",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-05

## Summary

- 5 new casks classified
- 2 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `esphome-device-builder` | developerTools | utilities | 0.75 | A configuration/build tool for ESPHome IoT device firmware, closest to developer/embedded tooling. |
| `kirocrew` | developerTools | ai | 0.80 | AI-powered multi-agent development workspace tool for developers. |
| `koreader` | productivity | utilities | 0.70 | KOReader is a document/e-book viewer app, fitting productivity with a utility trait. |
| `meetingrecorder` | videoMedia | productivity, ai | 0.75 | Records meeting audio/system sound with AI transcription features, blending media capture with productivity. |
| `tauritavern` | productivity | ai | 0.70 | Native client for SillyTavern, an AI chat/roleplay frontend, so it's an AI-powered chat productivity app. |

## Manual review required

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `koreader` | productivity | utilities | 0.70 | KOReader is a document/e-book viewer app, fitting productivity with a utility trait. |
| `tauritavern` | productivity | ai | 0.70 | Native client for SillyTavern, an AI chat/roleplay frontend, so it's an AI-powered chat productivity app. |
