### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-05",
-  "totalCasks": 3856,
+  "generatedDate": "2026-08-06",
+  "totalCasks": 3857,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -3660,6 +3660,12 @@
       "primary": "developerTools",
       "secondary": [
         "cloudStorage"
+      ]
+    },
+    "diversion-app": {
+      "primary": "developerTools",
+      "secondary": [
+        "games"
       ]
     },
     "divvy": {

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,11 +1,11 @@
 # Daily classification update
 
-Generated 2026-08-05
+Generated 2026-08-06
 
 ## Summary
 
-- 5 new casks classified
-- 2 classifications require manual review (confidence below 0.75)
+- 1 new casks classified
+- 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
@@ -15,15 +15,4 @@ Generated 2026-08-05
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `esphome-device-builder` | developerTools | utilities | 0.75 | A configuration/build tool for ESPHome IoT device firmware, closest to developer/embedded tooling. |
-| `kirocrew` | developerTools | ai | 0.80 | AI-powered multi-agent development workspace tool for developers. |
-| `koreader` | productivity | utilities | 0.70 | KOReader is a document/e-book viewer app, fitting productivity with a utility trait. |
-| `meetingrecorder` | videoMedia | productivity, ai | 0.75 | Records meeting audio/system sound with AI transcription features, blending media capture with productivity. |
-| `tauritavern` | productivity | ai | 0.70 | Native client for SillyTavern, an AI chat/roleplay frontend, so it's an AI-powered chat productivity app. |
-
-## Manual review required
-
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `koreader` | productivity | utilities | 0.70 | KOReader is a document/e-book viewer app, fitting productivity with a utility trait. |
-| `tauritavern` | productivity | ai | 0.70 | Native client for SillyTavern, an AI chat/roleplay frontend, so it's an AI-powered chat productivity app. |
+| `diversion-app` | developerTools | games | 0.90 | Diversion is a version control system aimed at developers and game development teams. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -6277,6 +6277,13 @@
     "og_desc": "Diversion is scalable version control for game development, Unreal Engine, Unity, 3D and AI - a modern alternative to Perforce, Git, and SVN."
   },
   {
+    "token": "diversion-app",
+    "homepage": "https://www.diversion.dev/",
+    "title": "Diversion: Scalable Version Control",
+    "meta_desc": "Diversion is scalable version control for game development, Unreal Engine, Unity, 3D and AI - a modern alternative to Perforce, Git, and SVN.",
+    "og_desc": "Diversion is scalable version control for game development, Unreal Engine, Unity, 3D and AI - a modern alternative to Perforce, Git, and SVN."
+  },
+  {
     "token": "divvy",
     "homepage": "https://mizage.com/divvy/",
     "title": "Mizage - Divvy",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-06

## Summary

- 1 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `diversion-app` | developerTools | games | 0.90 | Diversion is a version control system aimed at developers and game development teams. |
