### PR TITLE
docs: Add Applite to projects using CaskFlow

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -72,6 +72,7 @@ La clasificación real admite `anthropic`, `openai`, `groq` y `cloudflare`; elig
 | Proyecto | Descripción | Categorías | Fechas&nbsp;de&nbsp;adición | Iconos |
 |---|---|:---:|:---:|:---:|
 | [CaskHub](https://github.com/alielsokary/CaskHub) | Aplicación nativa para macOS para descubrir, instalar y administrar casks de Homebrew | ✅ | ✅ | ✅ |
+| [Applite](https://github.com/milanvarady/Applite) | Aplicación macOS con interfaz gráfica y fácil de usar para casks de Homebrew | - | - | ✅ |
 | [*Añade&nbsp;el&nbsp;tuyo*](https://github.com/alielsokary/CaskFlow/edit/develop/README.md) | ¿Usas datos de CaskFlow en tu proyecto? Añádelo a esta tabla | - | - | - |
 
 ## Atribución

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Real classification supports `anthropic`, `openai`, `groq`, and `cloudflare`; ch
 | Project | Description | Categories | Added&nbsp;Dates | Icons |
 |---|---|:---:|:---:|:---:|
 | [CaskHub](https://github.com/alielsokary/CaskHub) | Native macOS app for discovering, installing, and managing Homebrew casks | ✅ | ✅ | ✅ |
+| [Applite](https://github.com/milanvarady/Applite) | User-friendly GUI macOS application for Homebrew casks | - | - | ✅ |
 | [*Add&nbsp;yours*](https://github.com/alielsokary/CaskFlow/edit/develop/README.md) | Using CaskFlow data in your project? Add it to this table | - | - | - |
 
 ## Attribution


### PR DESCRIPTION
Adds [Applite](https://github.com/milanvarady/Applite) to the Projects using CaskFlow table in both README.md and README.es-ES.md. Applite consumes the icons asset only.