### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-06",
-  "totalCasks": 3857,
+  "generatedDate": "2026-08-08",
+  "totalCasks": 3858,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -2094,6 +2094,12 @@
     "captains-deck": {
       "primary": "utilities",
       "secondary": []
+    },
+    "captin": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
     },
     "capto": {
       "primary": "videoMedia",
@@ -15270,7 +15276,7 @@
       "primary": "utilities",
       "secondary": []
     },
-    "unraid-usb-creator-next": {
+    "unraid-usb-creator": {
       "primary": "utilities",
       "secondary": []
     },

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,18 +1,22 @@
 # Daily classification update
 
-Generated 2026-08-06
+Generated 2026-08-08
 
 ## Summary
 
 - 1 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
-- 0 casks renamed in Homebrew (classification migrated, no LLM call)
+- 1 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
 - 0 casks deprecated/disabled in Homebrew (pruned)
+
+## Renamed (classification migrated)
+
+- `unraid-usb-creator-next` → `unraid-usb-creator`
 
 ## New classifications
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `diversion-app` | developerTools | games | 0.90 | Diversion is a version control system aimed at developers and game development teams. |
+| `captin` | utilities | menuBar | 0.80 | A small menu-bar utility that displays caps lock status. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -3618,6 +3618,13 @@
     "og_desc": "The dual-pane file manager for macOS power users. Better than Finder, ForkLift, and Commander One. Built-in terminal, SFTP, S3, and Total Commander-style navigation."
   },
   {
+    "token": "captin",
+    "homepage": "https://github.com/cool8jay/public",
+    "title": "GitHub - cool8jay/public: Public resources. · GitHub",
+    "meta_desc": "Public resources. Contribute to cool8jay/public development by creating an account on GitHub.",
+    "og_desc": "Public resources. Contribute to cool8jay/public development by creating an account on GitHub."
+  },
+  {
     "token": "capto",
     "homepage": "https://www.globaldelight.com/capto/",
     "title": "Capto - Screen Capture and Video Editing Software for Mac",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-08

## Summary

- 1 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 1 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## Renamed (classification migrated)

- `unraid-usb-creator-next` → `unraid-usb-creator`

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `captin` | utilities | menuBar | 0.80 | A small menu-bar utility that displays caps lock status. |
