### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-08",
-  "totalCasks": 3858,
+  "generatedDate": "2026-08-09",
+  "totalCasks": 3860,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -2049,6 +2049,12 @@
       "primary": "productivity",
       "secondary": []
     },
+    "canario": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "candy-crisis": {
       "primary": "games",
       "secondary": []
@@ -2136,6 +2142,12 @@
     "cashnotify": {
       "primary": "financeCrypto",
       "secondary": []
+    },
+    "caskhub": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
     },
     "castr": {
       "primary": "videoMedia",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,22 +1,19 @@
 # Daily classification update
 
-Generated 2026-08-08
+Generated 2026-08-09
 
 ## Summary
 
-- 1 new casks classified
+- 2 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
-- 1 casks renamed in Homebrew (classification migrated, no LLM call)
+- 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
 - 0 casks deprecated/disabled in Homebrew (pruned)
-
-## Renamed (classification migrated)
-
-- `unraid-usb-creator-next` → `unraid-usb-creator`
 
 ## New classifications
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `captin` | utilities | menuBar | 0.80 | A small menu-bar utility that displays caps lock status. |
+| `canario` | developerTools | utilities | 0.90 | Canario is a terminal emulator built on Rio's engine, a developer tool for command-line use. |
+| `caskhub` | utilities | productivity | 0.85 | CaskHub is a native app store/manager for Homebrew casks, a system utility for installing and managing apps. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -3543,6 +3543,13 @@
     "og_desc": "Camunda's process orchestration platform allows developers to design, automate and improve processes. Start your free trial today."
   },
   {
+    "token": "canario",
+    "homepage": "https://rioterm.com/canario",
+    "title": "Canario | Rio Terminal",
+    "meta_desc": "Canario is a Rio spin-off for macOS: spaces, splits, a command bar, live tab previews and a summonable quick terminal, built on Rio's terminal engine.",
+    "og_desc": "Canario is a Rio spin-off for macOS: spaces, splits, a command bar, live tab previews and a summonable quick terminal, built on Rio's terminal engine."
+  },
+  {
     "token": "candy-crisis",
     "homepage": "https://candycrisis.sourceforge.net/",
     "error": "HTTP 403"
@@ -3693,6 +3700,13 @@
     "title": "CashNotify - Payment notifications app for Stripe and PayPal",
     "meta_desc": "CashNotify is the easiest way to monitor your Stripe and PayPal payments. Get real-time notifications for new sales and failed payments.",
     "og_desc": "CashNotify is the easiest way to monitor your Stripe and PayPal payments. Get real-time notifications for new sales and failed payments."
+  },
+  {
+    "token": "caskhub",
+    "homepage": "https://caskhub.app/",
+    "title": "CaskHub: a native Mac app store for Homebrew casks",
+    "meta_desc": "Browse, search, install, update, and uninstall thousands of Mac apps distributed through Homebrew, in a clean native SwiftUI interface. 100% free and open source.",
+    "og_desc": "Browse, install, update, and uninstall thousands of Mac apps from Homebrew, with one-click actions in a native SwiftUI app. Free and open source."
   },
   {
     "token": "castr",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-09

## Summary

- 2 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `canario` | developerTools | utilities | 0.90 | Canario is a terminal emulator built on Rio's engine, a developer tool for command-line use. |
| `caskhub` | utilities | productivity | 0.85 | CaskHub is a native app store/manager for Homebrew casks, a system utility for installing and managing apps. |
