### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-09",
-  "totalCasks": 3860,
+  "generatedDate": "2026-08-10",
+  "totalCasks": 3865,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -5976,6 +5976,13 @@
         "utilities"
       ]
     },
+    "headroom": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai",
+        "menuBar"
+      ]
+    },
     "headset": {
       "primary": "audioMusic",
       "secondary": []
@@ -9918,6 +9925,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "omegat": {
+      "primary": "productivity",
+      "secondary": [
+        "scienceEducation"
+      ]
+    },
     "omnidisksweeper": {
       "primary": "utilities",
       "secondary": []
@@ -12872,6 +12885,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "shell360": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "sherlock-app": {
       "primary": "developerTools",
       "secondary": []
@@ -13454,6 +13473,10 @@
       "secondary": []
     },
     "space-capsule": {
+      "primary": "utilities",
+      "secondary": []
+    },
+    "space-rabbit": {
       "primary": "utilities",
       "secondary": []
     },
@@ -14468,6 +14491,12 @@
     "textmate": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "textream": {
+      "primary": "videoMedia",
+      "secondary": [
+        "productivity"
+      ]
     },
     "textsniper": {
       "primary": "utilities",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,11 +1,11 @@
 # Daily classification update
 
-Generated 2026-08-09
+Generated 2026-08-10
 
 ## Summary
 
-- 2 new casks classified
-- 0 classifications require manual review (confidence below 0.75)
+- 5 new casks classified
+- 2 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
@@ -15,5 +15,15 @@ Generated 2026-08-09
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `canario` | developerTools | utilities | 0.90 | Canario is a terminal emulator built on Rio's engine, a developer tool for command-line use. |
-| `caskhub` | utilities | productivity | 0.85 | CaskHub is a native app store/manager for Homebrew casks, a system utility for installing and managing apps. |
+| `headroom` | developerTools | ai, menuBar | 0.75 | A menu bar utility that optimizes prompts for AI coding tools like Claude Code and Codex, tying it closely to developer workflows. |
+| `omegat` | productivity | scienceEducation | 0.70 | OmegaT is a translation memory tool aiding professional translators, fitting productivity software with a language/education angle. |
+| `shell360` | developerTools | utilities | 0.85 | SSH/SFTP client falls under developer tools per scope rules. |
+| `space-rabbit` | utilities | - | 0.85 | A system tweak utility that removes macOS Spaces switching animation. |
+| `textream` | videoMedia | productivity | 0.70 | A teleprompter app for streamers/presenters is primarily a video/media production tool with productivity aspects. |
+
+## Manual review required
+
+| token | primary | secondary | confidence | reason |
+|---|---|---|---|---|
+| `omegat` | productivity | scienceEducation | 0.70 | OmegaT is a translation memory tool aiding professional translators, fitting productivity software with a language/education angle. |
+| `textream` | videoMedia | productivity | 0.70 | A teleprompter app for streamers/presenters is primarily a video/media production tool with productivity aspects. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -28214,6 +28214,13 @@
     "og_desc": ""
   },
   {
+    "token": "headroom",
+    "homepage": "https://extraheadroom.com/",
+    "title": "Payhawk logo",
+    "meta_desc": "Headroom is a menu bar app that trims prompt bloat before it reaches Claude Code and Codex, cutting token spend ~50% so the plan you already pay for lasts 2x longer.",
+    "og_desc": "Headroom is a menu bar app that trims prompt bloat before it reaches Claude Code and Codex, cutting token spend ~50% so the plan you already pay for lasts 2x longer."
+  },
+  {
     "token": "headset",
     "homepage": "https://headsetapp.co/",
     "title": "Headset - Desktop Music Player Powered by YouTube And Reddit",
@@ -41685,6 +41692,13 @@
     "og_desc": "macOS spaces in a grid"
   },
   {
+    "token": "space-rabbit",
+    "homepage": "https://space-rabbit.app/",
+    "title": "Instant Space Switching for macOS | Space Rabbit",
+    "meta_desc": "Space Rabbit removes the macOS Spaces slide animation. Zero delay, zero config.",
+    "og_desc": "Space Rabbit removes the macOS Spaces slide animation. Zero delay, zero config."
+  },
+  {
     "token": "space-saver",
     "homepage": "https://www.mariogt.com/space-saver.html",
     "title": "Space Saver",
@@ -43594,6 +43608,13 @@
     "title": "TextMate: Text editor for macOS",
     "meta_desc": "",
     "og_desc": ""
+  },
+  {
+    "token": "textream",
+    "homepage": "https://github.com/f/textream",
+    "title": "GitHub - f/textream: Textream is a free macOS teleprompter app for streamers, interviewers, and presenters. It highlights your script in real-time as you speak, displayed in a beautiful Dynamic Island overlay. With extensible features. · GitHub",
+    "meta_desc": "Textream is a free macOS teleprompter app for streamers, interviewers, and presenters. It highlights your script in real-time as you speak, displayed in a beautiful Dynamic Island overlay. With extensible features. - f/textream",
+    "og_desc": "Textream is a free macOS teleprompter app for streamers, interviewers, and presenters. It highlights your script in real-time as you speak, displayed in a beautiful Dynamic Island overlay. With ext..."
   },
   {
     "token": "textsniper",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-10

## Summary

- 5 new casks classified
- 2 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `headroom` | developerTools | ai, menuBar | 0.75 | A menu bar utility that optimizes prompts for AI coding tools like Claude Code and Codex, tying it closely to developer workflows. |
| `omegat` | productivity | scienceEducation | 0.70 | OmegaT is a translation memory tool aiding professional translators, fitting productivity software with a language/education angle. |
| `shell360` | developerTools | utilities | 0.85 | SSH/SFTP client falls under developer tools per scope rules. |
| `space-rabbit` | utilities | - | 0.85 | A system tweak utility that removes macOS Spaces switching animation. |
| `textream` | videoMedia | productivity | 0.70 | A teleprompter app for streamers/presenters is primarily a video/media production tool with productivity aspects. |

## Manual review required

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `omegat` | productivity | scienceEducation | 0.70 | OmegaT is a translation memory tool aiding professional translators, fitting productivity software with a language/education angle. |
| `textream` | videoMedia | productivity | 0.70 | A teleprompter app for streamers/presenters is primarily a video/media production tool with productivity aspects. |
