### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-10",
-  "totalCasks": 3865,
+  "generatedDate": "2026-08-11",
+  "totalCasks": 3864,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -9554,12 +9554,6 @@
     "network-radar": {
       "primary": "utilities",
       "secondary": []
-    },
-    "netxms-console": {
-      "primary": "utilities",
-      "secondary": [
-        "developerTools"
-      ]
     },
     "nexonplug": {
       "primary": "games",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,29 +1,16 @@
 # Daily classification update
 
-Generated 2026-08-10
+Generated 2026-08-11
 
 ## Summary
 
-- 5 new casks classified
-- 2 classifications require manual review (confidence below 0.75)
+- 0 new casks classified
+- 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
-- 0 casks deprecated/disabled in Homebrew (pruned)
+- 1 casks deprecated/disabled in Homebrew (pruned)
 
-## New classifications
+## Deprecated/disabled (pruned)
 
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `headroom` | developerTools | ai, menuBar | 0.75 | A menu bar utility that optimizes prompts for AI coding tools like Claude Code and Codex, tying it closely to developer workflows. |
-| `omegat` | productivity | scienceEducation | 0.70 | OmegaT is a translation memory tool aiding professional translators, fitting productivity software with a language/education angle. |
-| `shell360` | developerTools | utilities | 0.85 | SSH/SFTP client falls under developer tools per scope rules. |
-| `space-rabbit` | utilities | - | 0.85 | A system tweak utility that removes macOS Spaces switching animation. |
-| `textream` | videoMedia | productivity | 0.70 | A teleprompter app for streamers/presenters is primarily a video/media production tool with productivity aspects. |
-
-## Manual review required
-
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `omegat` | productivity | scienceEducation | 0.70 | OmegaT is a translation memory tool aiding professional translators, fitting productivity software with a language/education angle. |
-| `textream` | videoMedia | productivity | 0.70 | A teleprompter app for streamers/presenters is primarily a video/media production tool with productivity aspects. |
+- `netxms-console`


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-11

## Summary

- 0 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 1 casks deprecated/disabled in Homebrew (pruned)

## Deprecated/disabled (pruned)

- `netxms-console`
