### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-18",
-  "totalCasks": 3876,
+  "generatedDate": "2026-08-19",
+  "totalCasks": 3879,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -1376,6 +1376,12 @@
     "bazecor": {
       "primary": "utilities",
       "secondary": []
+    },
+    "bb": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "bbackupp": {
       "primary": "utilities",
@@ -4062,6 +4068,10 @@
       "secondary": [
         "ai"
       ]
+    },
+    "easydmg": {
+      "primary": "utilities",
+      "secondary": []
     },
     "easyfind": {
       "primary": "utilities",
@@ -11691,6 +11701,12 @@
       "secondary": []
     },
     "qlmarkdown": {
+      "primary": "utilities",
+      "secondary": [
+        "developerTools"
+      ]
+    },
+    "qmk-toolbox": {
       "primary": "utilities",
       "secondary": [
         "developerTools"

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,10 +1,10 @@
 # Daily classification update
 
-Generated 2026-08-18
+Generated 2026-08-19
 
 ## Summary
 
-- 1 new casks classified
+- 3 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
@@ -15,4 +15,6 @@ Generated 2026-08-18
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `contour` | developerTools | - | 0.95 | Contour is a terminal emulator, a core developer tool. |
+| `bb` | developerTools | ai | 0.85 | An IDE for orchestrating AI coding agents fits developer tools with an AI trait. |
+| `easydmg` | utilities | - | 0.90 | A system utility that automates DMG installation on macOS. |
+| `qmk-toolbox` | utilities | developerTools | 0.75 | QMK Toolbox flashes and debugs custom keyboard firmware, a system-level utility with developer flavor. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -2328,6 +2328,13 @@
     "og_desc": "With a programmable keyboard the possibilities are limitless. Remap keys, create macros, set up layers... you name it! Increase your producitivity and smooth out your workflow."
   },
   {
+    "token": "bb",
+    "homepage": "https://getbb.app/",
+    "title": "OpenAI",
+    "meta_desc": "bb can control, customize, and automate itself, laying the groundwork for your own software factory. Fully open source and local-first, with Claude Code, Codex, Cursor, Pi, OpenCode, Grok, omp, and Hermes.",
+    "og_desc": "bb can control, customize, and automate itself, laying the groundwork for your own software factory."
+  },
+  {
     "token": "bbackupp",
     "homepage": "https://github.com/Lakr233/BBackupp",
     "title": "GitHub - Lakr233/BBackupp: Automated iOS Backup Robot · GitHub",
@@ -6957,6 +6964,13 @@
     "title": "GitHub - tisfeng/Easydict: 一个简洁优雅的词典翻译 macOS App。开箱即用，支持离线 OCR 识别，支持有道词典，🍎 苹果系统词典，🍎 苹果系统翻译，OpenAI，Gemini，DeepL，Google，Bing，腾讯，百度，阿里，小牛，彩云和火山翻译。A concise and elegant Dictionary and Translator macOS App for looking up words and translating text. · GitHub",
     "meta_desc": "一个简洁优雅的词典翻译 macOS App。开箱即用，支持离线 OCR 识别，支持有道词典，🍎 苹果系统词典，🍎 苹果系统翻译，OpenAI，Gemini，DeepL，Google，Bing，腾讯，百度，阿里，小牛，彩云和火山翻译。A concise and elegant Dictionary and Translator macOS App for looking up words and translating text.  - GitHub - tisfeng/Easydict: 一个简洁优雅的词典翻译 macOS App。开箱即用，支持离线 OCR 识别，支持有道词典，🍎 苹果系统词典，🍎 苹果系统翻译，OpenAI，Gemini，DeepL，Google，Bing，腾讯，百度，阿里，小牛，彩云和火山翻译。A concise and elegant Dictionary and Translator macOS App for looking up words and translating text.",
     "og_desc": "一个简洁优雅的词典翻译 macOS App。开箱即用，支持离线 OCR 识别，支持有道词典，🍎 苹果系统词典，🍎 苹果系统翻译，OpenAI，Gemini，DeepL，Google，Bing，腾讯，百度，阿里，小牛，彩云和火山翻译。A concise and elegant Dictionary and Translator macOS App for looking up words an..."
+  },
+  {
+    "token": "easydmg",
+    "homepage": "https://easydmg.app/",
+    "title": "EasyDMG - Automated DMG Installs for macOS",
+    "meta_desc": "EasyDMG makes installing Mac apps from DMG files a single click. Set it as your default DMG handler and never drag-and-drop again.",
+    "og_desc": "EasyDMG makes installing Mac apps from DMG files a single click. Set it as your default DMG handler and never drag-and-drop again."
   },
   {
     "token": "easyfind",
@@ -38447,6 +38461,13 @@
     "title": "GitHub - Marginal/QuickLookVideo: This package allows macOS Finder to display thumbnails, static QuickLook previews, cover art and metadata for most types of video files. · GitHub",
     "meta_desc": "This package allows macOS Finder to display thumbnails, static QuickLook previews, cover art and metadata for most types of video files. - Marginal/QuickLookVideo",
     "og_desc": "This package allows macOS Finder to display thumbnails, static QuickLook previews, cover art and metadata for most types of video files. - Marginal/QuickLookVideo"
+  },
+  {
+    "token": "qmk-toolbox",
+    "homepage": "https://qmk.fm/",
+    "title": "QMK Firmware",
+    "meta_desc": "Open-source keyboard firmware for Atmel AVR and Arm USB families",
+    "og_desc": ""
   },
   {
     "token": "qobuz",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-19

## Summary

- 3 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `bb` | developerTools | ai | 0.85 | An IDE for orchestrating AI coding agents fits developer tools with an AI trait. |
| `easydmg` | utilities | - | 0.90 | A system utility that automates DMG installation on macOS. |
| `qmk-toolbox` | utilities | developerTools | 0.75 | QMK Toolbox flashes and debugs custom keyboard firmware, a system-level utility with developer flavor. |
