### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-20",
-  "totalCasks": 3882,
+  "generatedDate": "2026-08-21",
+  "totalCasks": 3881,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -15073,10 +15073,6 @@
     },
     "tripmode": {
       "primary": "utilities",
-      "secondary": []
-    },
-    "tritium": {
-      "primary": "productivity",
       "secondary": []
     },
     "trivial": {

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,20 +1,16 @@
 # Daily classification update
 
-Generated 2026-08-20
+Generated 2026-08-21
 
 ## Summary
 
-- 3 new casks classified
+- 0 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
-- 0 casks deprecated/disabled in Homebrew (pruned)
+- 1 casks deprecated/disabled in Homebrew (pruned)
 
-## New classifications
+## Deprecated/disabled (pruned)
 
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `clickhouse` | developerTools | - | 0.95 | ClickHouse is a database management system, fitting developer tools. |
-| `ghost-downloader` | utilities | - | 0.85 | A multithreaded download manager is a system-level utility. |
-| `monet` | developerTools | ai | 0.85 | A desktop app for managing and driving AI coding agent sessions (Claude Code, Codex), aimed at developers. |
+- `tritium`


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-21

## Summary

- 0 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 1 casks deprecated/disabled in Homebrew (pruned)

## Deprecated/disabled (pruned)

- `tritium`
