### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-22",
-  "totalCasks": 3882,
+  "generatedDate": "2026-08-23",
+  "totalCasks": 3883,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -7192,6 +7192,12 @@
     "keystore-explorer": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "keyty": {
+      "primary": "utilities",
+      "secondary": [
+        "videoMedia"
+      ]
     },
     "kicad": {
       "primary": "developerTools",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,6 +1,6 @@
 # Daily classification update
 
-Generated 2026-08-22
+Generated 2026-08-23
 
 ## Summary
 
@@ -15,4 +15,4 @@ Generated 2026-08-22
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `topcat` | scienceEducation | productivity | 0.85 | TOPCAT is a tool for viewing and analyzing astronomical tabular data, used in scientific research. |
+| `keyty` | utilities | videoMedia | 0.75 | A keyboard/mouse input visualizer is a system utility often used for screen recordings and demos. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -30462,6 +30462,13 @@
     "og_desc": ""
   },
   {
+    "token": "keyty",
+    "homepage": "https://keyty.app/",
+    "title": "Keyty - Keyboard and Mouse Visualizer for macOS",
+    "meta_desc": "Display keyboard shortcuts, keystrokes, mouse clicks, and scrolling in real time for macOS demos, recordings, and livestreams.",
+    "og_desc": "Display keyboard shortcuts, keystrokes, mouse clicks, and scrolling in real time for macOS demos, recordings, and livestreams."
+  },
+  {
     "token": "kicad",
     "homepage": "https://kicad.org/",
     "title": "KiCad - Schematic Capture & PCB Design Software",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-23

## Summary

- 1 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `keyty` | utilities | videoMedia | 0.75 | A keyboard/mouse input visualizer is a system utility often used for screen recordings and demos. |
