### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-26",
-  "totalCasks": 3900,
+  "generatedDate": "2026-08-27",
+  "totalCasks": 3903,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -2294,12 +2294,6 @@
         "ai"
       ]
     },
-    "chatgpt-atlas": {
-      "primary": "browsers",
-      "secondary": [
-        "ai"
-      ]
-    },
     "chatgpt-classic": {
       "primary": "productivity",
       "secondary": [
@@ -3125,6 +3119,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "crisp": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
+      ]
+    },
     "cro-mag-rally": {
       "primary": "games",
       "secondary": []
@@ -3326,6 +3326,12 @@
     "datweatherdoe": {
       "primary": "menuBar",
       "secondary": []
+    },
+    "davit": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "dayflow": {
       "primary": "productivity",
@@ -11127,6 +11133,12 @@
       "primary": "productivity",
       "secondary": []
     },
+    "pixcake": {
+      "primary": "designGraphics",
+      "secondary": [
+        "ai"
+      ]
+    },
     "pixel-shift-combiner": {
       "primary": "designGraphics",
       "secondary": []
@@ -15510,6 +15522,12 @@
     "unshaky": {
       "primary": "utilities",
       "secondary": []
+    },
+    "unsloth": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "updatest": {
       "primary": "utilities",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,29 +1,25 @@
 # Daily classification update
 
-Generated 2026-08-26
+Generated 2026-08-27
 
 ## Summary
 
-- 6 new casks classified
-- 1 classifications require manual review (confidence below 0.75)
+- 4 new casks classified
+- 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
-- 0 casks deprecated/disabled in Homebrew (pruned)
+- 1 casks deprecated/disabled in Homebrew (pruned)
 
 ## New classifications
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `bifrost` | utilities | - | 0.75 | A firmware downloader for Samsung devices is a system/download utility tool. |
-| `itraffic` | menuBar | utilities | 0.85 | A menu bar status app that monitors and displays network traffic per process. |
-| `keychron-assistant` | utilities | - | 0.75 | Companion configuration tool for Keychron keyboard hardware, fitting system utility/peripheral configurator category. |
-| `leigod` | utilities | games | 0.75 | A network accelerator tool that optimizes game connections, which is a system-level networking utility geared toward gaming. |
-| `librewolf` | browsers | securityPrivacy | 0.97 | LibreWolf is a privacy-focused Firefox-based web browser. |
-| `nativ` | productivity | ai, developerTools | 0.70 | A local AI model runner app, best fit as a productivity tool with AI trait and developer relevance. |
+| `crisp` | utilities | menuBar | 0.85 | A display management utility for brightness, HiDPI, and virtual displays that lives in the menu bar. |
+| `davit` | developerTools | utilities | 0.90 | A GUI for managing Apple's container CLI (containers, images, volumes) is a developer tool similar to Docker Desktop. |
+| `pixcake` | designGraphics | ai | 0.85 | AI-powered photo editing software for commercial photography retouching. |
+| `unsloth` | developerTools | ai | 0.85 | Unsloth is a local tool for training and running AI models, a developer-focused ML task. |
 
-## Manual review required
+## Deprecated/disabled (pruned)
 
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `nativ` | productivity | ai, developerTools | 0.70 | A local AI model runner app, best fit as a productivity tool with AI trait and developer relevance. |
+- `chatgpt-atlas`

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -5328,6 +5328,13 @@
     "og_desc": "Crescendo is a swift based, real time event viewer for macOS. It utilizes Apple's Endpoint Security Framework. - SuprHackerSteve/Crescendo"
   },
   {
+    "token": "crisp",
+    "homepage": "https://crispmac.app/",
+    "title": "Crisp: Free BetterDisplay & Lunar alternative for macOS",
+    "meta_desc": "Crisp is a free, open-source, lightweight alternative to BetterDisplay and Lunar for macOS: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar.",
+    "og_desc": "A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar."
+  },
+  {
     "token": "cro-mag-rally",
     "homepage": "https://jorio.itch.io/cromagrally",
     "title": "Cro-Mag Rally by Iliyas Jorio",
@@ -5668,6 +5675,13 @@
     "title": "GitHub - inderdhir/DatWeatherDoe: Simple menu bar weather app for macOS · GitHub",
     "meta_desc": "Simple menu bar weather app for macOS. Contribute to inderdhir/DatWeatherDoe development by creating an account on GitHub.",
     "og_desc": "Simple menu bar weather app for macOS. Contribute to inderdhir/DatWeatherDoe development by creating an account on GitHub."
+  },
+  {
+    "token": "davit",
+    "homepage": "https://davit.app/",
+    "title": "Davit - a native macOS UI for Apple containers",
+    "meta_desc": "Davit is a free, open-source, fully native macOS app for Apple's container platform: containers, images, volumes and networks with live stats, logs, file browsing, private registries, Compose import, Dockerfile builds and one-click setup.",
+    "og_desc": "Free, open-source, fully native. Run Linux containers on Apple silicon with Apple's container platform; no Docker Desktop required."
   },
   {
     "token": "dayflow",
@@ -37435,6 +37449,13 @@
     "og_desc": "Tools for using PIV tokens (like Yubikeys) as an SSH agent, for encrypting data at rest, and more - arekinath/pivy"
   },
   {
+    "token": "pixcake",
+    "homepage": "https://www.pixcakeai.com/",
+    "title": "像素蛋糕PixCake - 像素级AI精修软件",
+    "meta_desc": "",
+    "og_desc": ""
+  },
+  {
     "token": "pixel-shift-combiner",
     "homepage": "https://www.fujifilm-x.com/en-us/support/download/software/pixel-shift-combiner/",
     "title": "FUJIFILM Pixel Shift Combiner | Support | Downloads | Software | FUJIFILM X Series & GFX - USA",
@@ -45345,6 +45366,13 @@
     "title": "GitHub - aahung/Unshaky: A software attempt to address the \"double key press\" issue on Apple's butterfly keyboard [not actively maintained] · GitHub",
     "meta_desc": "A software attempt to address the \"double key press\" issue on Apple's butterfly keyboard [not actively maintained] - aahung/Unshaky",
     "og_desc": "A software attempt to address the \"double key press\" issue on Apple's butterfly keyboard [not actively maintained] - aahung/Unshaky"
+  },
+  {
+    "token": "unsloth",
+    "homepage": "https://unsloth.ai/",
+    "title": "Unsloth - Run and Train Models Locally",
+    "meta_desc": "Unsloth is an open-source, no-code deskop UI for training and running open models on your local hardware.",
+    "og_desc": "Unsloth is an open-source, no-code deskop UI for training and running open models on your local hardware."
   },
   {
     "token": "updatest",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-27

## Summary

- 4 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 1 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `crisp` | utilities | menuBar | 0.85 | A display management utility for brightness, HiDPI, and virtual displays that lives in the menu bar. |
| `davit` | developerTools | utilities | 0.90 | A GUI for managing Apple's container CLI (containers, images, volumes) is a developer tool similar to Docker Desktop. |
| `pixcake` | designGraphics | ai | 0.85 | AI-powered photo editing software for commercial photography retouching. |
| `unsloth` | developerTools | ai | 0.85 | Unsloth is a local tool for training and running AI models, a developer-focused ML task. |

## Deprecated/disabled (pruned)

- `chatgpt-atlas`
