### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-28",
-  "totalCasks": 3903,
+  "generatedDate": "2026-08-29",
+  "totalCasks": 3906,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -348,6 +348,10 @@
     },
     "affinity": {
       "primary": "designGraphics",
+      "secondary": []
+    },
+    "afterglow": {
+      "primary": "screensaverWallpaper",
       "secondary": []
     },
     "agent-tars": {
@@ -3980,6 +3984,13 @@
     "droplr": {
       "primary": "utilities",
       "secondary": []
+    },
+    "droppy": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar",
+        "productivity"
+      ]
     },
     "dropshare": {
       "primary": "cloudStorage",
@@ -14518,6 +14529,12 @@
       "primary": "productivity",
       "secondary": [
         "ai"
+      ]
+    },
+    "tcp-viewer": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
       ]
     },
     "tdr-kotelnikov": {

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,28 +1,26 @@
 # Daily classification update
 
-Generated 2026-08-28
+Generated 2026-08-29
 
 ## Summary
 
-- 1 new casks classified
+- 3 new casks classified
 - 1 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
-- 1 casks deprecated/disabled in Homebrew (pruned)
+- 0 casks deprecated/disabled in Homebrew (pruned)
 
 ## New classifications
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `arm-performix` | developerTools | utilities | 0.70 | Performance analysis toolkit for server/cloud environments is a developer/system profiling tool. |
+| `afterglow` | screensaverWallpaper | - | 0.98 | Afterglow emulates classic After Dark screen savers on macOS. |
+| `droppy` | utilities | menuBar, productivity | 0.70 | A notch-based file tray and clipboard manager utility that lives in the menu bar area.' |
+| `tcp-viewer` | developerTools | utilities | 0.85 | Native macOS packet capture and inspection tool for TCP traffic, similar to Wireshark, aimed at developers. |
 
 ## Manual review required
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `arm-performix` | developerTools | utilities | 0.70 | Performance analysis toolkit for server/cloud environments is a developer/system profiling tool. |
-
-## Deprecated/disabled (pruned)
-
-- `virtual-ii`
+| `droppy` | utilities | menuBar, productivity | 0.70 | A notch-based file tray and clipboard manager utility that lives in the menu bar area.' |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -551,6 +551,13 @@
     "og_desc": ""
   },
   {
+    "token": "afterglow",
+    "homepage": "https://morphing.cloud/afterglow/",
+    "title": "Afterglow - classic After Dark screen savers on modern macOS",
+    "meta_desc": "Afterglow runs classic After Dark screen saver modules - Flying Toasters, Fish!, Starry Skyline, and more - natively on macOS, with no ROMs required.",
+    "og_desc": "Run classic After Dark screen saver modules - Flying Toasters, Fish!, Starry Skyline, and more - natively on macOS."
+  },
+  {
     "token": "agent-tars",
     "homepage": "https://github.com/bytedance/UI-TARS-desktop",
     "title": "GitHub - bytedance/UI-TARS-desktop: The Open-Source Multimodal AI Agent Stack: Connecting Cutting-Edge AI Models and Agent Infra · GitHub",
@@ -6813,6 +6820,13 @@
     "title": "Droplr",
     "meta_desc": "Discover the best screen capture software apps for Mac and PC. Top-rated screen recorders with audio and video capture for all your screen recording needs.",
     "og_desc": "Discover the best screen capture software apps for Mac and PC. Top-rated screen recorders with audio and video capture for all your screen recording needs."
+  },
+  {
+    "token": "droppy",
+    "homepage": "https://getdroppy.app/",
+    "title": "Droppy. Your Mac, just way better.",
+    "meta_desc": "Droppy turns your Mac's notch into a file tray, clipboard manager, media hub and live activities, with a revamped lock screen. Works with or without a notch. One-time license, macOS 14+.",
+    "og_desc": "A file tray, clipboard manager, revamped lock screen, music controls and live activities. Everything in reach, notch or not."
   },
   {
     "token": "dropshare",
@@ -43499,6 +43513,13 @@
     "title": "TauriTavern",
     "meta_desc": "TauriTavern 文档站：围绕 Tauri v2、Rust 后端与 SillyTavern 1.18.0 前端兼容的工程文档。",
     "og_desc": "TauriTavern 的架构、API 与开发文档站点。"
+  },
+  {
+    "token": "tcp-viewer",
+    "homepage": "https://tcpviewer.proxyman.com/",
+    "title": "TCP Viewer - Native macOS Packet Capture and Inspection",
+    "meta_desc": "A simpler, Mac-native Wireshark alternative for inspecting TCP traffic.",
+    "og_desc": "A simpler, Mac-native Wireshark alternative for inspecting TCP traffic."
   },
   {
     "token": "tdr-kotelnikov",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-29

## Summary

- 3 new casks classified
- 1 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `afterglow` | screensaverWallpaper | - | 0.98 | Afterglow emulates classic After Dark screen savers on macOS. |
| `droppy` | utilities | menuBar, productivity | 0.70 | A notch-based file tray and clipboard manager utility that lives in the menu bar area.' |
| `tcp-viewer` | developerTools | utilities | 0.85 | Native macOS packet capture and inspection tool for TCP traffic, similar to Wireshark, aimed at developers. |

## Manual review required

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `droppy` | utilities | menuBar, productivity | 0.70 | A notch-based file tray and clipboard manager utility that lives in the menu bar area.' |
