### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-29",
-  "totalCasks": 3906,
+  "generatedDate": "2026-08-30",
+  "totalCasks": 3907,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -4749,6 +4749,10 @@
     },
     "fellow": {
       "primary": "productivity",
+      "secondary": []
+    },
+    "fender-universal-control": {
+      "primary": "audioMusic",
       "secondary": []
     },
     "ferdium": {
@@ -11489,10 +11493,6 @@
         "designGraphics"
       ]
     },
-    "presonus-universal-control": {
-      "primary": "audioMusic",
-      "secondary": []
-    },
     "prettyclean": {
       "primary": "utilities",
       "secondary": []
@@ -13321,6 +13321,12 @@
     "sizzy": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "sjmcl": {
+      "primary": "games",
+      "secondary": [
+        "utilities"
+      ]
     },
     "sketch": {
       "primary": "designGraphics",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,26 +1,22 @@
 # Daily classification update
 
-Generated 2026-08-29
+Generated 2026-08-30
 
 ## Summary
 
-- 3 new casks classified
-- 1 classifications require manual review (confidence below 0.75)
+- 1 new casks classified
+- 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
-- 0 casks renamed in Homebrew (classification migrated, no LLM call)
+- 1 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
 - 0 casks deprecated/disabled in Homebrew (pruned)
+
+## Renamed (classification migrated)
+
+- `presonus-universal-control` → `fender-universal-control`
 
 ## New classifications
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `afterglow` | screensaverWallpaper | - | 0.98 | Afterglow emulates classic After Dark screen savers on macOS. |
-| `droppy` | utilities | menuBar, productivity | 0.70 | A notch-based file tray and clipboard manager utility that lives in the menu bar area.' |
-| `tcp-viewer` | developerTools | utilities | 0.85 | Native macOS packet capture and inspection tool for TCP traffic, similar to Wireshark, aimed at developers. |
-
-## Manual review required
-
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `droppy` | utilities | menuBar, productivity | 0.70 | A notch-based file tray and clipboard manager utility that lives in the menu bar area.' |
+| `sjmcl` | games | utilities | 0.85 | A Minecraft launcher is primarily a game-related tool for launching and managing the game. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -41300,6 +41300,13 @@
     "og_desc": "Develop, debug and test your website with ease and speed. Intuitive and quick development tools help you focus on your product and ideas."
   },
   {
+    "token": "sjmcl",
+    "homepage": "https://mc.sjtu.cn/sjmcl/",
+    "title": "SJMC Launcher | 新一代开源跨平台 Minecraft 启动器",
+    "meta_desc": "Docs for the SJMC Launcher",
+    "og_desc": ""
+  },
+  {
     "token": "sketch",
     "homepage": "https://www.sketch.com/",
     "title": "icon-close",


### PR DESCRIPTION
# Daily classification update

Generated 2026-08-30

## Summary

- 1 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 1 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## Renamed (classification migrated)

- `presonus-universal-control` → `fender-universal-control`

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `sjmcl` | games | utilities | 0.85 | A Minecraft launcher is primarily a game-related tool for launching and managing the game. |
