### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-08-31",
-  "totalCasks": 3911,
+  "generatedDate": "2026-09-01",
+  "totalCasks": 3913,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -901,6 +901,10 @@
       "secondary": []
     },
     "aptakube": {
+      "primary": "developerTools",
+      "secondary": []
+    },
+    "aptible": {
       "primary": "developerTools",
       "secondary": []
     },
@@ -16112,6 +16116,12 @@
     "wakatime": {
       "primary": "menuBar",
       "secondary": []
+    },
+    "waku": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
     },
     "wallpaper-wizard": {
       "primary": "screensaverWallpaper",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,10 +1,10 @@
 # Daily classification update
 
-Generated 2026-08-31
+Generated 2026-09-01
 
 ## Summary
 
-- 4 new casks classified
+- 2 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
@@ -15,7 +15,5 @@ Generated 2026-08-31
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `markviewer` | productivity | developerTools | 0.85 | A minimal markdown viewer/editor for writing and viewing markdown files, closely related to developer tools. |
-| `quarkclouddrive` | cloudStorage | utilities | 0.95 | Quark Cloud Drive is a cloud storage and file sync/management client. |
-| `tabularis` | developerTools | ai | 0.90 | A desktop database client for PostgreSQL/MySQL/SQLite with AI features is a developer tool. |
-| `token-monitor` | developerTools | ai, menuBar | 0.75 | Monitors token usage and costs for AI coding tools, closely tied to developer workflows and likely displayed in the menu bar.' |
+| `aptible` | developerTools | - | 0.90 | CLI tool for managing app deployment resources on Aptible platform. |
+| `waku` | developerTools | ai | 0.90 | A native desktop app for managing coding agents like Claude Code, Codex, and Cursor is a developer tool with AI focus. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -1511,6 +1511,13 @@
     "og_desc": "Aptakube is the best Kubernetes GUI. A lightweight, modern, multi-cluster desktop client to manage your clusters"
   },
   {
+    "token": "aptible",
+    "homepage": "https://www.aptible.com/docs/reference/aptible-cli/overview",
+    "title": "Aptible CLI - Overview - Aptible",
+    "meta_desc": "Learn more about using the Aptible CLI for managing resources",
+    "og_desc": "Learn more about using the Aptible CLI for managing resources"
+  },
+  {
     "token": "aqua-data-studio",
     "homepage": "https://aquadatastudio.com/",
     "error": "HTTP 403"
@@ -46361,6 +46368,13 @@
     "title": "X",
     "meta_desc": "Open source IDE plugins for programmers.",
     "og_desc": "An open source Mac system tray app for automatic time tracking and metrics generated from your programming activity."
+  },
+  {
+    "token": "waku",
+    "homepage": "https://waku.sh/",
+    "title": "Waku - one native app for all your coding agents",
+    "meta_desc": "A fast, native app for local coding agents. Amp, Claude Code, Codex, Cursor, OpenCode, Grok, and Pi - one timeline, entirely on your machine.",
+    "og_desc": "A fast, native app for local coding agents. Amp, Claude Code, Codex, Cursor, OpenCode, Grok, and Pi - one timeline, entirely on your machine."
   },
   {
     "token": "wallpaper-wizard",


### PR DESCRIPTION
# Daily classification update

Generated 2026-09-01

## Summary

- 2 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `aptible` | developerTools | - | 0.90 | CLI tool for managing app deployment resources on Aptible platform. |
| `waku` | developerTools | ai | 0.90 | A native desktop app for managing coding agents like Claude Code, Codex, and Cursor is a developer tool with AI focus. |
