### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-09-01",
-  "totalCasks": 3913,
+  "generatedDate": "2026-09-02",
+  "totalCasks": 3915,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -3355,6 +3355,12 @@
       "primary": "developerTools",
       "secondary": []
     },
+    "db-pro": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "dbeaver-community": {
       "primary": "developerTools",
       "secondary": []
@@ -3806,6 +3812,12 @@
     "dockdoor": {
       "primary": "utilities",
       "secondary": []
+    },
+    "dockdoor-pro": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
     },
     "docker-desktop": {
       "primary": "developerTools",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,6 +1,6 @@
 # Daily classification update
 
-Generated 2026-09-01
+Generated 2026-09-02
 
 ## Summary
 
@@ -15,5 +15,5 @@ Generated 2026-09-01
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `aptible` | developerTools | - | 0.90 | CLI tool for managing app deployment resources on Aptible platform. |
-| `waku` | developerTools | ai | 0.90 | A native desktop app for managing coding agents like Claude Code, Codex, and Cursor is a developer tool with AI focus. |
+| `db-pro` | developerTools | ai | 0.90 | A database management/query tool for developers with built-in AI chat features. |
+| `dockdoor-pro` | utilities | productivity | 0.80 | A dock replacement enhancing window management and system UI is a system-level utility. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -5731,6 +5731,13 @@
     "og_desc": ""
   },
   {
+    "token": "db-pro",
+    "homepage": "https://www.dbpro.app/",
+    "title": "DB Pro - Modern Database Management",
+    "meta_desc": "Query, explore, and manage your databases with a powerful yet intuitive interface. Built for developers who demand speed, reliability, and elegant workflows to export.",
+    "og_desc": "Query, explore, and manage PostgreSQL, MySQL, SQLite, and more with a powerful desktop app, collaborative web workspaces, and built-in AI chat."
+  },
+  {
     "token": "dbeaver-community",
     "homepage": "https://dbeaver.io/",
     "title": "DBeaver Community | Free Open-Source Database Management Tool",
@@ -6481,6 +6488,13 @@
     "title": "DockDoor - Free Alt+Tab and Dock Preview Window Switcher for Mac | Download Now",
     "meta_desc": "Transform your Mac workflow with DockDoor's free Alt+Tab switcher & dock previews. Privacy-first, open-source window management. Download instantly!",
     "og_desc": "Transform your Mac workflow with DockDoor's free Alt+Tab switcher & dock previews. Privacy-first, open-source window management. Download instantly!"
+  },
+  {
+    "token": "dockdoor-pro",
+    "homepage": "https://pro.dockdoor.net/",
+    "title": "DockDoor Pro - Native Dock Experience for macOS",
+    "meta_desc": "DockDoor Pro is a native dock replacement for macOS with live window previews, dock profiles, media controls, file tray, magnification, multi-monitor support, and full customization.",
+    "og_desc": "DockDoor Pro is a native dock replacement for macOS with live window previews, dock profiles, media controls, file tray, magnification, multi-monitor support, and full customization."
   },
   {
     "token": "docker-desktop",


### PR DESCRIPTION
# Daily classification update

Generated 2026-09-02

## Summary

- 2 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `db-pro` | developerTools | ai | 0.90 | A database management/query tool for developers with built-in AI chat features. |
| `dockdoor-pro` | utilities | productivity | 0.80 | A dock replacement enhancing window management and system UI is a system-level utility. |
