### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-09-02",
-  "totalCasks": 3915,
+  "generatedDate": "2026-09-03",
+  "totalCasks": 3919,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -456,6 +456,12 @@
     "airserver": {
       "primary": "utilities",
       "secondary": []
+    },
+    "airstats": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
     },
     "airsync": {
       "primary": "utilities",
@@ -1329,10 +1335,6 @@
     },
     "banana-cake-pop": {
       "primary": "developerTools",
-      "secondary": []
-    },
-    "bananas": {
-      "primary": "utilities",
       "secondary": []
     },
     "bankid": {
@@ -2526,6 +2528,13 @@
     "claudebar": {
       "primary": "menuBar",
       "secondary": [
+        "ai"
+      ]
+    },
+    "clawd-on-desk": {
+      "primary": "utilities",
+      "secondary": [
+        "developerTools",
         "ai"
       ]
     },
@@ -8241,6 +8250,12 @@
         "utilities"
       ]
     },
+    "macshot-offline": {
+      "primary": "utilities",
+      "secondary": [
+        "designGraphics"
+      ]
+    },
     "macskk": {
       "primary": "utilities",
       "secondary": []
@@ -10668,6 +10683,10 @@
     },
     "oxygen-xml-editor": {
       "primary": "developerTools",
+      "secondary": []
+    },
+    "p2p-kiwi": {
+      "primary": "utilities",
       "secondary": []
     },
     "p4": {
@@ -15059,6 +15078,10 @@
       "secondary": [
         "ai"
       ]
+    },
+    "tone3000": {
+      "primary": "audioMusic",
+      "secondary": []
     },
     "toneprint": {
       "primary": "utilities",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,19 +1,31 @@
 # Daily classification update
 
-Generated 2026-09-02
+Generated 2026-09-03
 
 ## Summary
 
-- 2 new casks classified
-- 0 classifications require manual review (confidence below 0.75)
+- 4 new casks classified
+- 1 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
-- 0 casks renamed in Homebrew (classification migrated, no LLM call)
+- 1 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
 - 0 casks deprecated/disabled in Homebrew (pruned)
+
+## Renamed (classification migrated)
+
+- `bananas` → `p2p-kiwi`
 
 ## New classifications
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `db-pro` | developerTools | ai | 0.90 | A database management/query tool for developers with built-in AI chat features. |
-| `dockdoor-pro` | utilities | productivity | 0.80 | A dock replacement enhancing window management and system UI is a system-level utility. |
+| `airstats` | menuBar | utilities | 0.95 | A menu bar system monitor showing CPU/memory metrics is primarily a menu bar utility. |
+| `clawd-on-desk` | utilities | developerTools, ai | 0.60 | A desktop pet novelty tool that monitors AI coding agents, blending utility and developer tool traits with an AI focus. |
+| `macshot-offline` | utilities | designGraphics | 0.75 | A screenshot and screen recording tool with annotation features fits system utilities with design-related overlap. |
+| `tone3000` | audioMusic | - | 0.90 | An amp modeling plug-in and community for guitar/bass tone captures, squarely audio music software. |
+
+## Manual review required
+
+| token | primary | secondary | confidence | reason |
+|---|---|---|---|---|
+| `clawd-on-desk` | utilities | developerTools, ai | 0.60 | A desktop pet novelty tool that monitors AI coding agents, blending utility and developer tool traits with an AI focus. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -719,6 +719,13 @@
     "og_desc": ""
   },
   {
+    "token": "airstats",
+    "homepage": "https://airstats.app/",
+    "title": "AirStats · A menu bar system monitor for macOS",
+    "meta_desc": "Sixteen metrics in your Mac's menu bar for 0.046% CPU. One process. Free, open source, 8.9 MB.",
+    "og_desc": "Sixteen metrics in your Mac's menu bar for 0.046% CPU. One process. Free, open source, 8.9 MB."
+  },
+  {
     "token": "airsync",
     "homepage": "https://github.com/sameerasw/airsync-mac",
     "title": "GitHub - sameerasw/airsync-mac: AirSync macOS - Bring the forbidden macOS continuity to Android · GitHub",
@@ -4316,6 +4323,13 @@
     "title": "GitHub - tddworks/ClaudeBar: A macOS menu bar application that monitors AI coding assistant usage quotas. Keep track of your Claude, Codex, Antigravity ,and Gemini usage at a glance. · GitHub",
     "meta_desc": "A macOS menu bar application that monitors AI coding assistant usage quotas. Keep track of your Claude, Codex, Antigravity ,and Gemini usage at a glance. - tddworks/ClaudeBar",
     "og_desc": "A macOS menu bar application that monitors AI coding assistant usage quotas. Keep track of your Claude, Codex, Antigravity ,and Gemini usage at a glance. - tddworks/ClaudeBar"
+  },
+  {
+    "token": "clawd-on-desk",
+    "homepage": "https://github.com/rullerzhou-afk/clawd-on-desk",
+    "title": "GitHub - rullerzhou-afk/clawd-on-desk: A pixel desktop pet that watches Claude Code, Codex, Cursor & other AI coding agents - so you don't have to. · GitHub",
+    "meta_desc": "A pixel desktop pet that watches Claude Code, Codex, Cursor & other AI coding agents - so you don't have to. - rullerzhou-afk/clawd-on-desk",
+    "og_desc": "A pixel desktop pet that watches Claude Code, Codex, Cursor & other AI coding agents - so you don't have to. - rullerzhou-afk/clawd-on-desk"
   },
   {
     "token": "clay",
@@ -32191,6 +32205,13 @@
     "og_desc": "Feature-packed native macOS screenshot &amp; recording tool: annotate, auto-redact PII, record GIFs, OCR + translate, scroll capture, beautify, and more. No Electron, no subscription. - sw33tLie/ma..."
   },
   {
+    "token": "macshot-offline",
+    "homepage": "https://github.com/sw33tLie/macshot",
+    "title": "GitHub - sw33tLie/macshot: Feature-packed native macOS screenshot & recording tool: annotate, auto-redact PII, record GIFs, OCR + translate, scroll capture, beautify, and more. No Electron, no subscription. · GitHub",
+    "meta_desc": "Feature-packed native macOS screenshot & recording tool: annotate, auto-redact PII, record GIFs, OCR + translate, scroll capture, beautify, and more. No Electron, no subscription. - sw33tLie/macshot",
+    "og_desc": "Feature-packed native macOS screenshot &amp; recording tool: annotate, auto-redact PII, record GIFs, OCR + translate, scroll capture, beautify, and more. No Electron, no subscription. - sw33tLie/ma..."
+  },
+  {
     "token": "macskk",
     "homepage": "https://github.com/mtgto/macSKK",
     "title": "GitHub - mtgto/macSKK: Yet Another macOS SKK Input Method · GitHub",
@@ -44509,6 +44530,13 @@
     "title": "Tolaria - A second brain for the AI era",
     "meta_desc": "Organize your notes as Markdown files. With native relationships, Git, and Claude Code integration. Free forever.",
     "og_desc": ""
+  },
+  {
+    "token": "tone3000",
+    "homepage": "https://www.tone3000.com/",
+    "title": "Tone3000 - NAM Captures and IRs",
+    "meta_desc": "TONE3000 is the world's largest community for guitar tones, bass tones and studio equipment captures. Discover and share IR's and NAM profiles of amps, pedals, rigs, outboards, and signal chains. It's free!",
+    "og_desc": "TONE3000 is the world's largest community for guitar tones, bass tones and studio equipment captures. Discover and share IR's and NAM profiles of amps, pedals, rigs, outboards, and signal chains. It's free!"
   },
   {
     "token": "toneprint",


### PR DESCRIPTION
# Daily classification update

Generated 2026-09-03

## Summary

- 4 new casks classified
- 1 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 1 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## Renamed (classification migrated)

- `bananas` → `p2p-kiwi`

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `airstats` | menuBar | utilities | 0.95 | A menu bar system monitor showing CPU/memory metrics is primarily a menu bar utility. |
| `clawd-on-desk` | utilities | developerTools, ai | 0.60 | A desktop pet novelty tool that monitors AI coding agents, blending utility and developer tool traits with an AI focus. |
| `macshot-offline` | utilities | designGraphics | 0.75 | A screenshot and screen recording tool with annotation features fits system utilities with design-related overlap. |
| `tone3000` | audioMusic | - | 0.90 | An amp modeling plug-in and community for guitar/bass tone captures, squarely audio music software. |

## Manual review required

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `clawd-on-desk` | utilities | developerTools, ai | 0.60 | A desktop pet novelty tool that monitors AI coding agents, blending utility and developer tool traits with an AI focus. |
