### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-09-04",
-  "totalCasks": 3925,
+  "generatedDate": "2026-09-05",
+  "totalCasks": 3927,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -355,6 +355,12 @@
       "secondary": []
     },
     "agent-tars": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
+    "agentide": {
       "primary": "developerTools",
       "secondary": [
         "ai"
@@ -8425,6 +8431,12 @@
     "mamp": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "mangodisk": {
+      "primary": "utilities",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "manico": {
       "primary": "utilities",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,10 +1,10 @@
 # Daily classification update
 
-Generated 2026-09-04
+Generated 2026-09-05
 
 ## Summary
 
-- 3 new casks classified
+- 2 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
@@ -15,6 +15,5 @@ Generated 2026-09-04
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `sxitch` | utilities | productivity | 0.80 | An app switcher replacing CMD-Tab is a system-level productivity utility. |
-| `terminal-browser` | browsers | developerTools | 0.80 | It's a real web browser that runs in the terminal, appealing to developer users. |
-| `vernier-graphical-analysis` | scienceEducation | - | 0.95 | Vernier Graphical Analysis is a science classroom data analysis tool for experiments. |
+| `agentide` | developerTools | ai | 0.85 | An IDE tailored for managing AI coding agents and worktrees, primarily a developer tool with AI trait. |
+| `mangodisk` | utilities | securityPrivacy | 0.90 | A disk cleaner and storage analyzer is a system-level utility, with some privacy cleanup features. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -565,6 +565,13 @@
     "og_desc": "The Open-Source Multimodal AI Agent Stack: Connecting Cutting-Edge AI Models and Agent Infra - bytedance/UI-TARS-desktop"
   },
   {
+    "token": "agentide",
+    "homepage": "https://github.com/MikeMcQuaid/AgentIDE",
+    "title": "GitHub - MikeMcQuaid/AgentIDE: 🪪 IDE for Agents: prompt a worktree, review another, ship a third, repeat · GitHub",
+    "meta_desc": "🪪 IDE for Agents: prompt a worktree, review another, ship a third, repeat - MikeMcQuaid/AgentIDE",
+    "og_desc": "🪪 IDE for Agents: prompt a worktree, review another, ship a third, repeat - MikeMcQuaid/AgentIDE"
+  },
+  {
     "token": "agentkube",
     "homepage": "https://agentkube.com/",
     "title": "",
@@ -32502,6 +32509,13 @@
     "title": "MAMP & MAMP PRO for macOS - Local Web Development Environment for PHP, MySQL & Apache",
     "meta_desc": "MAMP & MAMP PRO for macOS: Create a local server environment with Apache, MySQL, and PHP. Perfect for testing and developing websites. Download MAMP for free or try MAMP PRO with advanced tools!",
     "og_desc": ""
+  },
+  {
+    "token": "mangodisk",
+    "homepage": "https://mangodisk.app/",
+    "title": "MangoDisk - Deep Clean Your Disk and Free Up Space",
+    "meta_desc": "MangoDisk is a disk and privacy cleanup tool for macOS and Windows. Clean caches, large files, duplicates, app leftovers, and activity traces, analyze storage, manage startup items, and optimize your system.",
+    "og_desc": "MangoDisk is a disk and privacy cleanup tool for macOS and Windows. Clean caches, large files, duplicates, app leftovers, and activity traces, analyze storage, manage startup items, and optimize your system."
   },
   {
     "token": "manico",


### PR DESCRIPTION
# Daily classification update

Generated 2026-09-05

## Summary

- 2 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `agentide` | developerTools | ai | 0.85 | An IDE tailored for managing AI coding agents and worktrees, primarily a developer tool with AI trait. |
| `mangodisk` | utilities | securityPrivacy | 0.90 | A disk cleaner and storage analyzer is a system-level utility, with some privacy cleanup features. |
