### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-09-05",
-  "totalCasks": 3927,
+  "generatedDate": "2026-09-06",
+  "totalCasks": 3928,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -10173,6 +10173,12 @@
     "omnissa-horizon-client": {
       "primary": "utilities",
       "secondary": []
+    },
+    "omniwm": {
+      "primary": "utilities",
+      "secondary": [
+        "productivity"
+      ]
     },
     "ondesoft-audiobook-converter": {
       "primary": "audioMusic",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,10 +1,10 @@
 # Daily classification update
 
-Generated 2026-09-05
+Generated 2026-09-06
 
 ## Summary
 
-- 2 new casks classified
+- 1 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
@@ -15,5 +15,4 @@ Generated 2026-09-05
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `agentide` | developerTools | ai | 0.85 | An IDE tailored for managing AI coding agents and worktrees, primarily a developer tool with AI trait. |
-| `mangodisk` | utilities | securityPrivacy | 0.90 | A disk cleaner and storage analyzer is a system-level utility, with some privacy cleanup features. |
+| `omniwm` | utilities | productivity | 0.85 | A macOS tiling window manager is a system-level utility that enhances productivity workflows. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -35716,6 +35716,13 @@
     "error": "The read operation timed out"
   },
   {
+    "token": "omniwm",
+    "homepage": "https://omniwm.app/",
+    "title": "OmniWM - macOS tiling window manager, Niri & Hyprland style",
+    "meta_desc": "Free, open-source tiling window manager for macOS - Niri scrolling columns, Hyprland tiling, quake terminal, command palette, CLI. A yabai & AeroSpace alternative.",
+    "og_desc": "Free, open-source tiling window manager for macOS - Niri scrolling columns, Hyprland tiling, quake terminal, command palette, CLI. A yabai & AeroSpace alternative."
+  },
+  {
     "token": "ondesoft-audiobook-converter",
     "homepage": "https://www.ondesoft.com/audible-audiobook-converter.html",
     "title": "Ondesoft - iTunes DRM removal software, Apple Music Converter, Spotify Music Converter, Audible Converter, iTunes movie Converter",


### PR DESCRIPTION
# Daily classification update

Generated 2026-09-06

## Summary

- 1 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `omniwm` | utilities | productivity | 0.85 | A macOS tiling window manager is a system-level utility that enhances productivity workflows. |
