### PR TITLE
feat: Publish verified application bundle metadata

### DIFF
--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -10,6 +10,10 @@ on:
       tokens:
         description: "Specific tokens, space-separated (overrides limit)"
         default: ""
+      identity_backfill:
+        description: "Reinspect apps with missing or outdated identity metadata"
+        type: boolean
+        default: false
       retry_parked:
         description: "Retry all failed-parked tokens (overrides limit/tokens)"
         type: boolean
@@ -41,6 +45,7 @@ jobs:
           TOKENS: ${{ inputs.tokens }}
           LIMIT: ${{ inputs.limit || '300' }}
           RETRY_PARKED: ${{ inputs.retry_parked }}
+          IDENTITY_BACKFILL: ${{ inputs.identity_backfill }}
           CRON: ${{ github.event.schedule }}
         run: |
           if [ "$RETRY_PARKED" = "true" ] || [ "$CRON" = "7 3 1 * *" ]; then
@@ -49,6 +54,8 @@ jobs:
             # word-splitting intended: TOKENS is space-separated; the script
             # rejects anything that isn't a known cask token.
             python3 scripts/extract_icons.py --publish --tokens $TOKENS
+          elif [ "$IDENTITY_BACKFILL" = "true" ]; then
+            python3 scripts/extract_icons.py --publish --identity-backfill --limit "$LIMIT"
           else
             python3 scripts/extract_icons.py --publish --limit "$LIMIT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
     paths:
       - categories.json
+      - data/app_identity_variants.json
+      - app_identities.json
+      - scripts/app_identities.py
   # Recently Added is independent of classification. Refresh its mined dates
   # every day even when a classification PR is delayed or has nothing to merge.
   schedule:
@@ -48,6 +51,15 @@ jobs:
              + (if $icons[0] then {iconTokens: ($icons[0] | sort)} else {} end)' \
             categories.json > /tmp/stamped.json
           mv /tmp/stamped.json categories.json
+
+      - name: Compose app identity metadata
+        run: |
+          # Fail on fetch errors; only a missing first-rollout manifest uses the seed.
+          git fetch --depth=1 origin icons
+          if ! git show FETCH_HEAD:app_identities.json > /tmp/app_identities.json; then
+            cp app_identities.json /tmp/app_identities.json
+          fi
+          python3 scripts/app_identities.py --extracted /tmp/app_identities.json --seed app_identities.json
 
       - name: Compose release notes
         env:
@@ -99,5 +111,6 @@ jobs:
           files: |
             categories.json
             added_dates.json
+            app_identities.json
           fail_on_unmatched_files: true
           make_latest: true

--- a/app_identities.json
+++ b/app_identities.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": 1,
+  "casks": {
+    "motion": {
+      "caskVersion": "0.117.0",
+      "sourceURL": "https://github.com/usemotion/desktopapp/releases/download/0.117.0/motion-0.117.0-mac-aarch64.zip",
+      "artifactSHA256": "6a74ed0749a5089f1303d99fa257cc28e05be1a82c26d7b9fcf37a13902fe199",
+      "apps": [
+        {
+          "bundleName": "Motion.app",
+          "bundleIdentifier": "com.electron.motion"
+        }
+      ],
+      "reviewedVariants": []
+    },
+    "spark-app": {
+      "caskVersion": "3.3.2",
+      "sourceURL": "https://www.shadowlab.org/softwares/Spark/Spark.zip",
+      "artifactSHA256": "6f3cee4cccbec78fd413df0f68e66ca489707347be59a293ac6e82c0185d4fd1",
+      "apps": [
+        {
+          "bundleName": "Spark.app",
+          "bundleIdentifier": "com.xenonium.Spark"
+        }
+      ],
+      "reviewedVariants": []
+    },
+    "readdle-spark": {
+      "caskVersion": "3.30.10.140748",
+      "sourceURL": "https://downloads.sparkmailapp.com/Spark3/mac/dist/3.30.10.140748/Spark.zip",
+      "artifactSHA256": "b84de9fe848eaf0d51de04b37a428fabca041abc22a1163a8e12a927fa84a306",
+      "apps": [
+        {
+          "bundleName": "Spark Desktop.app",
+          "bundleIdentifier": "com.readdle.SparkDesktop"
+        }
+      ],
+      "reviewedVariants": [
+        {
+          "bundleName": "Spark Desktop.app",
+          "bundleIdentifier": "com.readdle.SparkDesktop.appstore",
+          "evidence": "Observed in the Mac App Store Spark Mail 3.30.9 Info.plist on 2026-09-06; App Store receipt present. Vendor: https://sparkmailapp.com/",
+          "reviewedDate": "2026-09-06"
+        }
+      ]
+    },
+    "tailscale-app": {
+      "apps": [],
+      "reviewedVariants": [
+        {
+          "bundleName": "Tailscale.app",
+          "bundleIdentifier": "io.tailscale.ipn.macos",
+          "evidence": "Vendor documentation identifies this as the Mac App Store variant: https://tailscale.com/kb/1286/macos-mdm",
+          "reviewedDate": "2026-09-06"
+        }
+      ]
+    },
+    "element": {
+      "caskVersion": "1.12.27",
+      "sourceURL": "https://packages.element.io/desktop/update/macos/Element-1.12.27-universal-mac.zip",
+      "artifactSHA256": "a9a577bcfbc2a2307525579fb9ca722ed70e9fd7d45e843dc9a297bba2bc1570",
+      "apps": [
+        {
+          "bundleName": "Element.app",
+          "bundleIdentifier": "im.riot.app"
+        }
+      ],
+      "reviewedVariants": []
+    }
+  }
+}

--- a/categories.json
+++ b/categories.json
@@ -17093,5 +17093,42 @@
       "primary": "utilities",
       "secondary": []
     }
-  }
+  },
+  "appIdentities": {
+    "element": [
+      {
+        "bundleName": "Element.app",
+        "bundleIdentifier": "im.riot.app"
+      }
+    ],
+    "motion": [
+      {
+        "bundleName": "Motion.app",
+        "bundleIdentifier": "com.electron.motion"
+      }
+    ],
+    "readdle-spark": [
+      {
+        "bundleName": "Spark Desktop.app",
+        "bundleIdentifier": "com.readdle.SparkDesktop"
+      },
+      {
+        "bundleName": "Spark Desktop.app",
+        "bundleIdentifier": "com.readdle.SparkDesktop.appstore"
+      }
+    ],
+    "spark-app": [
+      {
+        "bundleName": "Spark.app",
+        "bundleIdentifier": "com.xenonium.Spark"
+      }
+    ],
+    "tailscale-app": [
+      {
+        "bundleName": "Tailscale.app",
+        "bundleIdentifier": "io.tailscale.ipn.macos"
+      }
+    ]
+  },
+  "metadataUpdatedAt": "2026-09-06T15:31:43.404786+00:00"
 }

--- a/data/app_identity_variants.json
+++ b/data/app_identity_variants.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "casks": {
+    "readdle-spark": [
+      {
+        "bundleName": "Spark Desktop.app",
+        "bundleIdentifier": "com.readdle.SparkDesktop.appstore",
+        "evidence": "Observed in the Mac App Store Spark Mail 3.30.9 Info.plist on 2026-09-06; App Store receipt present. Vendor: https://sparkmailapp.com/",
+        "reviewedDate": "2026-09-06"
+      }
+    ],
+    "tailscale-app": [
+      {
+        "bundleName": "Tailscale.app",
+        "bundleIdentifier": "io.tailscale.ipn.macos",
+        "evidence": "Vendor documentation identifies this as the Mac App Store variant: https://tailscale.com/kb/1286/macos-mdm",
+        "reviewedDate": "2026-09-06"
+      }
+    ]
+  }
+}

--- a/docs/ICON_EXTRACTION.md
+++ b/docs/ICON_EXTRACTION.md
@@ -68,3 +68,41 @@ python3 scripts/extract_icons.py --publish --limit 300
 
 Backfill runs on GitHub-hosted macOS runners, and per-cask cleanup keeps disk flat.
 Stdlib + stock macOS tooling only - no extra dependencies.
+
+## App identity metadata
+
+Each successful archive inspection also writes `app_identities.json`. This is
+independent of icon extraction success. Entries record the cask version, source
+URL, actual archive SHA-256, installed bundle name, and `CFBundleIdentifier`.
+Only uniquely matched, explicitly declared `app` artifacts qualify. Source/target
+renames are honored; embedded helpers, symlinks, ambiguous duplicates, suite/pkg
+name guesses, and icon-selection fallbacks cannot establish app identity.
+Unsupported or ambiguous artifacts produce an empty `apps` list.
+
+The existing batch publisher merges only inspected tokens into the icons branch.
+Failed downloads leave previous evidence intact. Daily releases merge the
+checked-in seed with the branch manifest (fresh records win, including empty
+records), add reviewed App Store variants from `data/app_identity_variants.json`,
+and publish the resulting manifest. A compact `appIdentities` projection is
+embedded in `categories.json`, with `metadataUpdatedAt` allowing identity-only
+updates when the classification date is unchanged. Variant records require
+review evidence; neither shared names nor identifier prefixes prove a relation.
+
+Already-published icons need an explicit identity backfill. Use the workflow's
+`identity_backfill` input, or run locally without publishing:
+
+```sh
+python3 scripts/extract_icons.py --identity-backfill --limit 25 --output-dir /tmp/cask-identities
+```
+
+This reuses normal archive download and expansion, without installing apps.
+Backfill revisits missing records or changed cask versions, URLs, or checked
+SHA-256 values. An empty result is not retried until those inputs change. For
+rolling `no_check` archives, use `--tokens` to force a fresh inspection. Add
+`--publish` only when ready to update the icons branch. Package payload identities
+and coverage beyond inspected artifacts remain absent until verified.
+
+CaskHub consumes the optional projection using its release loader and bundled
+fallback. Older releases without the field remain readable. Unverified apps stay
+unassigned; a verified App Store variant can be recognized without becoming
+adoptable while its receipt is present.

--- a/scripts/app_identities.py
+++ b/scripts/app_identities.py
@@ -28,30 +28,30 @@ def load_manifest(path: Path) -> dict:
     return data
 
 
+def _app_entries(stanza: object) -> list[tuple[str, str]]:
+    if not isinstance(stanza, dict) or not isinstance(stanza.get("app"), list):
+        return []
+    entries = []
+    for item in stanza["app"]:
+        if isinstance(item, str):
+            entries.append((item, PurePosixPath(item).name))
+        elif isinstance(item, dict) and isinstance(item.get("target"), str) and entries:
+            entries[-1] = (entries[-1][0], PurePosixPath(item["target"]).name)
+    return entries
+
+
 def declared_apps(cask: dict) -> list[tuple[str, str]]:
     """Source artifact path and installed basename, honoring Homebrew target renames."""
     result = []
     for stanza in cask.get("artifacts") or []:
-        if not isinstance(stanza, dict):
-            continue
-        entries = []
-        app_artifacts = stanza.get("app")
-        if not isinstance(app_artifacts, list):
-            continue
-        for item in app_artifacts:
-            if isinstance(item, str):
-                entries.append((item, PurePosixPath(item).name))
-            elif isinstance(item, dict) and isinstance(item.get("target"), str) and entries:
-                entries[-1] = (entries[-1][0], PurePosixPath(item["target"]).name)
-        for source, target in entries:
+        for source, target in _app_entries(stanza):
             path = PurePosixPath(source)
             if not path.is_absolute() and ".." not in path.parts and source.endswith(".app") and target.endswith(".app"):
                 result.append((source, target))
     return result
 
 
-def extract_identities(cask: dict, root: Path, artifact: Path) -> dict:
-    """Inspect every declared app; reject duplicates, symlinks and heuristic selections."""
+def _application_bundles(root: Path) -> list[Path]:
     bundles = []
     for parent, directories, _ in os.walk(root, followlinks=False):
         for name in list(directories):
@@ -61,21 +61,32 @@ def extract_identities(cask: dict, root: Path, artifact: Path) -> dict:
             elif name.endswith(".app"):
                 bundles.append(path)
                 directories.remove(name)  # embedded helpers are not declared top-level apps
+    return bundles
+
+
+def _bundle_identifier(bundle: Path) -> str | None:
+    info_path = bundle / "Contents" / "Info.plist"
+    if info_path.is_symlink() or info_path.parent.is_symlink() or not info_path.resolve().is_relative_to(bundle.resolve()):
+        return None
+    try:
+        info = plistlib.loads(info_path.read_bytes())
+    except (OSError, ValueError, plistlib.InvalidFileException):
+        return None
+    identifier = info.get("CFBundleIdentifier") if isinstance(info, dict) else None
+    return identifier if isinstance(identifier, str) and IDENTIFIER.fullmatch(identifier) else None
+
+
+def extract_identities(cask: dict, root: Path, artifact: Path) -> dict:
+    """Inspect every declared app; reject duplicates, symlinks and heuristic selections."""
+    bundles = _application_bundles(root)
     apps = []
     for source, target in declared_apps(cask):
         parts = PurePosixPath(source).parts
         matches = [p for p in bundles if p.parts[-len(parts):] == parts]
         if len(matches) != 1:
             continue
-        info_path = matches[0] / "Contents" / "Info.plist"
-        if info_path.is_symlink() or info_path.parent.is_symlink() or not info_path.resolve().is_relative_to(matches[0].resolve()):
-            continue
-        try:
-            info = plistlib.loads(info_path.read_bytes())
-        except (OSError, ValueError, plistlib.InvalidFileException):
-            continue
-        identifier = info.get("CFBundleIdentifier") if isinstance(info, dict) else None
-        if isinstance(identifier, str) and IDENTIFIER.fullmatch(identifier):
+        identifier = _bundle_identifier(matches[0])
+        if identifier is not None:
             apps.append({"bundleName": target, "bundleIdentifier": identifier})
     digest = hashlib.sha256()
     with artifact.open("rb") as stream:
@@ -111,6 +122,16 @@ def merge_extractions(destination: Path, source: Path, dirty: set[str]) -> None:
     write_json(destination, base, trailing_newline=True)
 
 
+def _project_identity(token: str, record: dict, reviewed: list[dict]) -> dict:
+    identifier = record.get("bundleIdentifier", "")
+    name = record.get("bundleName", "")
+    if not IDENTIFIER.fullmatch(identifier) or not name.endswith(".app") or Path(name).name != name:
+        raise ValueError(f"Invalid identity for {token}")
+    if record in reviewed and not record.get("evidence"):
+        raise ValueError(f"Missing review evidence for {token}")
+    return {"bundleName": name, "bundleIdentifier": identifier}
+
+
 def compose_release(categories: Path, extracted: Path, variants: Path, output: Path,
                     seed: Path | None = None) -> None:
     """Keep provenance in the manifest and embed its matching projection in categories."""
@@ -127,13 +148,7 @@ def compose_release(categories: Path, extracted: Path, variants: Path, output: P
         records = entry.get("apps", []) + entry["reviewedVariants"]
         valid = []
         for record in records:
-            identifier = record.get("bundleIdentifier", "")
-            name = record.get("bundleName", "")
-            if not IDENTIFIER.fullmatch(identifier) or not name.endswith(".app") or Path(name).name != name:
-                raise ValueError(f"Invalid identity for {token}")
-            if record in entry["reviewedVariants"] and not record.get("evidence"):
-                raise ValueError(f"Missing review evidence for {token}")
-            projected = {"bundleName": name, "bundleIdentifier": identifier}
+            projected = _project_identity(token, record, entry["reviewedVariants"])
             if projected not in valid:
                 valid.append(projected)
         if valid:

--- a/scripts/app_identities.py
+++ b/scripts/app_identities.py
@@ -1,0 +1,155 @@
+"""Extract declared app identities and compose release metadata without name guesses."""
+#  Created by Ali Elsokary on 06/09/2026.
+#  Copyright © 2026 BuildingLink. All rights reserved.
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import plistlib
+import re
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+
+from style_standards import write_json
+
+MANIFEST = "app_identities.json"
+ROOT = Path(__file__).resolve().parent.parent
+IDENTIFIER = re.compile(r"[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+\Z")
+
+
+def load_manifest(path: Path) -> dict:
+    if not path.exists():
+        return {"schemaVersion": 1, "casks": {}}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schemaVersion") != 1 or not isinstance(data.get("casks"), dict):
+        raise ValueError(f"Unsupported identity manifest: {path}")
+    return data
+
+
+def declared_apps(cask: dict) -> list[tuple[str, str]]:
+    """Source artifact path and installed basename, honoring Homebrew target renames."""
+    result = []
+    for stanza in cask.get("artifacts") or []:
+        if not isinstance(stanza, dict):
+            continue
+        entries = []
+        app_artifacts = stanza.get("app")
+        if not isinstance(app_artifacts, list):
+            continue
+        for item in app_artifacts:
+            if isinstance(item, str):
+                entries.append((item, PurePosixPath(item).name))
+            elif isinstance(item, dict) and isinstance(item.get("target"), str) and entries:
+                entries[-1] = (entries[-1][0], PurePosixPath(item["target"]).name)
+        for source, target in entries:
+            path = PurePosixPath(source)
+            if not path.is_absolute() and ".." not in path.parts and source.endswith(".app") and target.endswith(".app"):
+                result.append((source, target))
+    return result
+
+
+def extract_identities(cask: dict, root: Path, artifact: Path) -> dict:
+    """Inspect every declared app; reject duplicates, symlinks and heuristic selections."""
+    bundles = []
+    for parent, directories, _ in os.walk(root, followlinks=False):
+        for name in list(directories):
+            path = Path(parent) / name
+            if path.is_symlink():
+                directories.remove(name)
+            elif name.endswith(".app"):
+                bundles.append(path)
+                directories.remove(name)  # embedded helpers are not declared top-level apps
+    apps = []
+    for source, target in declared_apps(cask):
+        parts = PurePosixPath(source).parts
+        matches = [p for p in bundles if p.parts[-len(parts):] == parts]
+        if len(matches) != 1:
+            continue
+        info_path = matches[0] / "Contents" / "Info.plist"
+        if info_path.is_symlink() or info_path.parent.is_symlink() or not info_path.resolve().is_relative_to(matches[0].resolve()):
+            continue
+        try:
+            info = plistlib.loads(info_path.read_bytes())
+        except (OSError, ValueError, plistlib.InvalidFileException):
+            continue
+        identifier = info.get("CFBundleIdentifier") if isinstance(info, dict) else None
+        if isinstance(identifier, str) and IDENTIFIER.fullmatch(identifier):
+            apps.append({"bundleName": target, "bundleIdentifier": identifier})
+    digest = hashlib.sha256()
+    with artifact.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {"caskVersion": cask.get("version"), "sourceURL": cask["url"],
+            "artifactSHA256": digest.hexdigest(), "apps": apps}
+
+
+def needs_refresh(cask: dict, entry: dict | None) -> bool:
+    if entry is None:
+        return True
+    checksum = cask.get("sha256")
+    return (entry.get("caskVersion") != cask.get("version")
+            or entry.get("sourceURL") != cask.get("url")
+            or (checksum not in (None, "no_check") and checksum != entry.get("artifactSHA256")))
+
+
+def record_extraction(cask: dict, root: Path, artifact: Path, output: Path) -> None:
+    manifest = load_manifest(output / MANIFEST)
+    manifest["casks"][cask["token"]] = extract_identities(cask, root, artifact)
+    write_json(output / MANIFEST, manifest, trailing_newline=True)
+
+
+def merge_extractions(destination: Path, source: Path, dirty: set[str]) -> None:
+    """Update only successfully inspected tokens; preserve concurrent batches and failures."""
+    if not source.exists():
+        return
+    base = load_manifest(destination)
+    incoming = load_manifest(source)["casks"]
+    for token in dirty & incoming.keys():
+        base["casks"][token] = incoming[token]
+    write_json(destination, base, trailing_newline=True)
+
+
+def compose_release(categories: Path, extracted: Path, variants: Path, output: Path,
+                    seed: Path | None = None) -> None:
+    """Keep provenance in the manifest and embed its matching projection in categories."""
+    catalog = json.loads(categories.read_text(encoding="utf-8"))
+    manifest = load_manifest(seed) if seed is not None else {"schemaVersion": 1, "casks": {}}
+    manifest["casks"].update(load_manifest(extracted)["casks"])
+    reviewed = load_manifest(variants)["casks"]
+    identities = {}
+    for token in sorted(manifest["casks"].keys() | reviewed.keys()):
+        if token not in catalog["tokenToCategory"]:
+            continue
+        entry = manifest["casks"].setdefault(token, {"apps": []})
+        entry["reviewedVariants"] = reviewed.get(token, [])
+        records = entry.get("apps", []) + entry["reviewedVariants"]
+        valid = []
+        for record in records:
+            identifier = record.get("bundleIdentifier", "")
+            name = record.get("bundleName", "")
+            if not IDENTIFIER.fullmatch(identifier) or not name.endswith(".app") or Path(name).name != name:
+                raise ValueError(f"Invalid identity for {token}")
+            if record in entry["reviewedVariants"] and not record.get("evidence"):
+                raise ValueError(f"Missing review evidence for {token}")
+            projected = {"bundleName": name, "bundleIdentifier": identifier}
+            if projected not in valid:
+                valid.append(projected)
+        if valid:
+            identities[token] = valid
+    catalog["appIdentities"] = identities
+    catalog["metadataUpdatedAt"] = datetime.now(timezone.utc).isoformat(timespec="microseconds")
+    write_json(categories, catalog, trailing_newline=True)
+    write_json(output, manifest, trailing_newline=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--categories", type=Path, default=ROOT / "categories.json")
+    parser.add_argument("--extracted", type=Path, required=True)
+    parser.add_argument("--variants", type=Path, default=ROOT / "data/app_identity_variants.json")
+    parser.add_argument("--seed", type=Path, help="Baseline identities; fresh extraction records take precedence")
+    parser.add_argument("--output", type=Path, default=ROOT / MANIFEST)
+    args = parser.parse_args()
+    compose_release(args.categories, args.extracted, args.variants, args.output, args.seed)

--- a/scripts/extract_icons.py
+++ b/scripts/extract_icons.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
+from app_identities import MANIFEST, merge_extractions, needs_refresh, record_extraction
+
 from icons_state import (  # noqa: F401  (re-exported for curate_icons/tests)
     ICONS_BRANCH,
     REPO_ROOT,
@@ -446,6 +448,7 @@ def extract_one(cask: dict, output_dir: Path) -> tuple[str, str]:
 
         root = expand(artifact, kind, workdir, mounts)
         hit = _locate_app(cask, root, kind, workdir, mounts)
+        record_extraction(cask, workdir, artifact, output_dir)
         if hit is None:
             # Deterministic outcome (e.g. suite/pkg of CLI binaries) - park it
             # rather than burning retries. --tokens bypasses parked entries.
@@ -492,7 +495,7 @@ def _icon_status(app: Path, selection: str, dest_png: Path) -> tuple[str, str]:
 
 
 def publish_batch(pngs: dict[str, Path], report: dict[str, dict],
-                  dirty: set[str]) -> None:
+                  dirty: set[str], identity_file: Path | None = None) -> None:
     """Commit a batch of icons AND the report to the icons branch via a throwaway worktree."""
     # Merge only this batch's report entries so concurrent manual audits survive.
     wt = Path(tempfile.mkdtemp(prefix="icons-wt-"))
@@ -503,6 +506,8 @@ def publish_batch(pngs: dict[str, Path], report: dict[str, dict],
         for token, png in pngs.items():
             shutil.copyfile(png, wt / f"{token}.png")
         _merge_report(wt, report, dirty)
+        if identity_file is not None:
+            merge_extractions(wt / MANIFEST, identity_file, dirty)
         _git(wt, "add", "-A")
         if _git(wt, "diff", "--cached", "--quiet").returncode == 0:
             return  # everything already on the branch
@@ -638,9 +643,10 @@ def _record_ok(token: str, detail: str, report: dict) -> None:
         record(report, token, "review", f"non-exact .app selection: {detail}")
 
 
-def _flush_if_due(report: dict, pending: dict[str, Path], dirty: set[str]) -> None:
-    if len(pending) >= FLUSH_EVERY:
-        publish_batch(pending, report, dirty)
+def _flush_if_due(report: dict, pending: dict[str, Path], dirty: set[str],
+                  identity_file: Path | None = None) -> None:
+    if len(pending) >= FLUSH_EVERY or len(dirty) >= FLUSH_EVERY:
+        publish_batch(pending, report, dirty, identity_file)
         pending.clear()
         dirty.clear()
 
@@ -648,6 +654,8 @@ def _flush_if_due(report: dict, pending: dict[str, Path], dirty: set[str]) -> No
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--tokens", nargs="*", help="Extract exactly these casks")
+    parser.add_argument("--identity-backfill", action="store_true",
+                        help="Reinspect existing icons whose identity metadata is missing or outdated")
     parser.add_argument("--retry-parked", action="store_true",
                         help="Retry every failed-parked token (attempts >= MAX_ATTEMPTS)")
     parser.add_argument("--limit", type=int, default=50, help="Batch cap (default 50)")
@@ -662,10 +670,25 @@ def main(argv: list[str] | None = None) -> int:
     by_token = {c["token"]: c for c in api_casks}
 
     report = load_report()
-    batch = _build_batch(args.tokens, by_token, api_casks, report, args.limit,
-                         retry_parked=args.retry_parked)
+    if args.identity_backfill and not args.tokens and not args.retry_parked:
+        show = _git(REPO_ROOT, "show", f"FETCH_HEAD:{MANIFEST}")
+        identities = json.loads(show.stdout).get("casks", {}) if show.returncode == 0 else {}
+        counts = load_install_counts()
+        from classify_new_casks import is_main_cask
+        batch = [c for c in api_casks if is_main_cask(c) and eligibility(c) is None
+                 and needs_refresh(c, identities.get(c["token"]))
+                 and report.get(c["token"], {}).get("attempts", 0) < MAX_ATTEMPTS]
+        batch.sort(key=lambda c: counts.get(c["token"], 0), reverse=True)
+        batch = batch[:args.limit]
+    else:
+        batch = _build_batch(args.tokens, by_token, api_casks, report, args.limit,
+                             retry_parked=args.retry_parked)
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
+    identity_file = args.output_dir / MANIFEST
+    # Never republish stale local records from an earlier invocation after a failed download.
+    from style_standards import write_json
+    write_json(identity_file, {"schemaVersion": 1, "casks": {}}, trailing_newline=True)
     print(f"Extracting {len(batch)} casks → {args.output_dir}"
           + (" (publishing)" if args.publish else " (local only)"))
 
@@ -683,9 +706,10 @@ def main(argv: list[str] | None = None) -> int:
             _record_ok(token, detail, report)
             if args.publish:
                 pending[token] = args.output_dir / f"{token}.png"
-                _flush_if_due(report, pending, dirty)
         else:
             record(report, token, status, detail)
+        if args.publish:
+            _flush_if_due(report, pending, dirty, identity_file)
         outcomes.append((token, status, detail))
         note = ""
         if status == "failed":
@@ -697,7 +721,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.publish:
         # Always flush at the end - persists report-only outcomes (failures,
         # parks) even when no new icons were extracted.
-        publish_batch(pending, report, dirty)
+        publish_batch(pending, report, dirty, identity_file)
     else:
         print("(local run - report changes not persisted; use --publish)")
 

--- a/tests/test_app_identities.py
+++ b/tests/test_app_identities.py
@@ -1,0 +1,137 @@
+"""Identity extraction must not turn icon-selection guesses into ownership evidence."""
+#  Created by Ali Elsokary on 06/09/2026.
+#  Copyright © 2026 BuildingLink. All rights reserved.
+import hashlib
+import json
+import plistlib
+
+import pytest
+
+from app_identities import (MANIFEST, compose_release, extract_identities,
+                            load_manifest, merge_extractions)
+from style_standards import write_json
+
+
+def app(root, name, identifier):
+    bundle = root / name
+    (bundle / "Contents").mkdir(parents=True)
+    (bundle / "Contents/Info.plist").write_bytes(plistlib.dumps({"CFBundleIdentifier": identifier}))
+    return bundle
+
+
+def cask():
+    return {"token": "sample", "version": "1", "url": "https://vendor.example/app.zip",
+            "artifacts": [{"app": ["Original.app", {"target": "Renamed.app"}]}]}
+
+
+def test_exact_artifact_rename_and_checksum_are_recorded(tmp_path):
+    app(tmp_path, "Original.app", "com.example.original")
+    app(tmp_path / "Original.app/Contents", "Helper.app", "com.example.helper")
+    archive = tmp_path / "app.zip"
+    archive.write_bytes(b"archive")
+    result = extract_identities(cask(), tmp_path, archive)
+    assert result == {"caskVersion": "1", "sourceURL": cask()["url"],
+                      "artifactSHA256": hashlib.sha256(b"archive").hexdigest(),
+                      "apps": [{"bundleName": "Renamed.app", "bundleIdentifier": "com.example.original"}]}
+
+
+@pytest.mark.parametrize("case", ["wrong-name", "duplicate", "symlink", "plist-symlink", "empty-id"])
+def test_ambiguous_or_untrusted_bundles_produce_no_identity(tmp_path, case):
+    archive = tmp_path / "app.zip"
+    archive.write_bytes(b"archive")
+    if case == "wrong-name":
+        app(tmp_path, "Similar.app", "com.example.similar")
+    elif case == "duplicate":
+        app(tmp_path / "one", "Original.app", "com.example.one")
+        app(tmp_path / "two", "Original.app", "com.example.two")
+    elif case == "symlink":
+        app(tmp_path, "Elsewhere.app", "com.example.elsewhere")
+        (tmp_path / "Original.app").symlink_to(tmp_path / "Elsewhere.app", target_is_directory=True)
+    elif case == "plist-symlink":
+        other = app(tmp_path, "Other.app", "com.example.other")
+        target = tmp_path / "Original.app/Contents"
+        target.mkdir(parents=True)
+        (target / "Info.plist").symlink_to(other / "Contents/Info.plist")
+    else:
+        app(tmp_path, "Original.app", "")
+    assert extract_identities(cask(), tmp_path, archive)["apps"] == []
+
+
+def test_identity_publication_merges_only_successfully_inspected_dirty_tokens(tmp_path):
+    destination, source = tmp_path / "published.json", tmp_path / "incoming.json"
+    write_json(destination, {"schemaVersion": 1, "casks": {"old": {"apps": [1]}, "failed": {"apps": [2]}}})
+    write_json(source, {"schemaVersion": 1, "casks": {"old": {"apps": []}, "not-dirty": {"apps": [3]}}})
+    merge_extractions(destination, source, {"old", "failed"})
+    assert load_manifest(destination)["casks"] == {"old": {"apps": []}, "failed": {"apps": [2]}}
+
+
+def test_release_projects_reviewed_variants_and_revokes_removed_aliases(tmp_path):
+    categories, extracted, variants = [tmp_path / name for name in ["categories.json", "extracted.json", "variants.json"]]
+    direct = {"bundleName": "Mail.app", "bundleIdentifier": "com.example.mail"}
+    store = {"bundleName": "Mail.app", "bundleIdentifier": "com.example.mail.store", "evidence": "Vendor docs"}
+    write_json(categories, {"tokenToCategory": {"mail": {"primary": "communication"}}})
+    write_json(extracted, {"schemaVersion": 1, "casks": {"mail": {"apps": [direct], "caskVersion": "1"}}})
+    write_json(variants, {"schemaVersion": 1, "casks": {"mail": [store]}})
+    output = tmp_path / MANIFEST
+    compose_release(categories, extracted, variants, output)
+    catalog = json.loads(categories.read_text())
+    assert catalog["appIdentities"]["mail"] == [direct, {k: v for k, v in store.items() if k != "evidence"}]
+    assert "metadataUpdatedAt" in catalog
+    assert load_manifest(output)["casks"]["mail"]["reviewedVariants"] == [store]
+    write_json(variants, {"schemaVersion": 1, "casks": {}})
+    compose_release(categories, output, variants, output)
+    assert json.loads(categories.read_text())["appIdentities"]["mail"] == [direct]
+
+
+def test_extraction_records_identity_even_when_app_has_no_extractable_icon(tmp_path, monkeypatch):
+    import extract_icons
+    root, output = tmp_path / "expanded", tmp_path / "output"
+    bundle = app(root, "Original.app", "com.example.original")
+    output.mkdir()
+    archive = root / "app.zip"
+    archive.write_bytes(b"archive")
+    monkeypatch.setattr(extract_icons.tempfile, "mkdtemp", lambda **kw: str(root))
+    monkeypatch.setattr(extract_icons, "download", lambda *args: archive)
+    monkeypatch.setattr(extract_icons, "expand", lambda *args: root)
+    monkeypatch.setattr(extract_icons, "_locate_app", lambda *args: (bundle, "exact"))
+    monkeypatch.setattr(extract_icons, "_icon_status", lambda *args: ("no_icon", "none"))
+    assert extract_icons.extract_one(cask(), output) == ("no_icon", "none")
+    assert load_manifest(output / MANIFEST)["casks"]["sample"]["apps"][0]["bundleIdentifier"] == "com.example.original"
+
+
+def test_backfill_revisits_missing_changed_sources_and_changed_checksums():
+    from app_identities import needs_refresh
+    source = cask()
+    source["sha256"] = "abc"
+    entry = {"caskVersion": "1", "sourceURL": source["url"], "artifactSHA256": "abc", "apps": []}
+    assert needs_refresh(source, None)
+    assert not needs_refresh(source, entry)  # a verified empty result is not retried forever
+    assert needs_refresh({**source, "sha256": "different"}, entry)
+    assert needs_refresh({**source, "url": "https://vendor.example/new.zip"}, entry)
+
+
+def test_identity_only_batch_is_flushed_without_a_png(tmp_path, monkeypatch):
+    import extract_icons
+    calls = []
+    monkeypatch.setattr(extract_icons, "FLUSH_EVERY", 1)
+    monkeypatch.setattr(extract_icons, "publish_batch", lambda *args: calls.append(args))
+    dirty = {"no-icon"}
+    extract_icons._flush_if_due({}, {}, dirty, tmp_path / MANIFEST)
+    assert len(calls) == 1
+    assert calls[0][3] == tmp_path / MANIFEST
+    assert not dirty
+
+
+def test_first_partial_publication_keeps_seed_and_honors_explicit_revocation(tmp_path):
+    categories, seed, extracted, variants, output = [tmp_path / name for name in
+        ["categories.json", "seed.json", "extracted.json", "variants.json", "output.json"]]
+    identity = {"bundleName": "Known.app", "bundleIdentifier": "org.example.known"}
+    write_json(categories, {"tokenToCategory": {"known": {}, "new": {}}})
+    write_json(seed, {"schemaVersion": 1, "casks": {"known": {"apps": [identity]}}})
+    write_json(extracted, {"schemaVersion": 1, "casks": {"new": {"apps": [identity]}}})
+    write_json(variants, {"schemaVersion": 1, "casks": {}})
+    compose_release(categories, extracted, variants, output, seed)
+    assert set(json.loads(categories.read_text())["appIdentities"]) == {"known", "new"}
+    write_json(extracted, {"schemaVersion": 1, "casks": {"known": {"apps": []}}})
+    compose_release(categories, extracted, variants, output, seed)
+    assert not json.loads(categories.read_text())["appIdentities"]

--- a/tests/test_extract_icons.py
+++ b/tests/test_extract_icons.py
@@ -287,7 +287,7 @@ def test_flush_clears_published_pending_and_dirty(monkeypatch, tmp_path):
     monkeypatch.setattr(
         extract_icons,
         "publish_batch",
-        lambda pngs, report, tokens: published.append((dict(pngs), set(tokens))),
+        lambda pngs, report, tokens, identity_file=None: published.append((dict(pngs), set(tokens))),
     )
 
     _flush_if_due({}, pending, dirty)

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -55,3 +55,12 @@ def test_pr_hygiene_can_assign_pull_requests():
 
     assert "pull-requests: write" in hygiene
     assert "issues: write" not in hygiene
+
+
+def test_identity_release_merges_seed_and_publishes_manifest():
+    release = _workflow("release.yml")
+    assert "scripts/app_identities.py --extracted /tmp/app_identities.json --seed app_identities.json" in release
+    assert "git fetch --depth=1 origin icons" in release
+    assert "            app_identities.json" in release
+    assert "data/app_identity_variants.json" in release
+    assert "--identity-backfill" in _workflow("extract-icons.yml")


### PR DESCRIPTION
## Summary

Apps with identical filenames can represent unrelated products, such as Apple Motion and Motion, Spark Classic and Shadowlab Spark, or Kushview Element and Element Matrix. Publish verified bundle identifiers so CaskHub can distinguish these apps without token-specific Swift exceptions.

- Extract identities from uniquely matched declared app artifacts during existing archive inspection, retaining source URL, version, and archive SHA-256. Keep reviewed App Store variants in a separate data file.
- Merge identity metadata into daily releases and embed an optional `appIdentities` projection in `categories.json`. Provide an explicit backfill for existing icons.
- Seed verified identities for Motion, Shadowlab Spark, Spark Mail, and Element Matrix, plus reviewed Spark Mail and Tailscale App Store variants. Unknown or ambiguous identities remain unassigned.

Related: alielsokary/CaskHub#219, alielsokary/CaskHub#218, alielsokary/CaskHub#175. This PR supplies the metadata, not the consumer fix.

## Verification

- `.venv/bin/python -m pytest -q`: 124 passed, including identity extraction, merge/revocation, workflow contracts, and typography checks. Repeated after rebasing onto develop.
- `git diff --check origin/develop...HEAD`: passed.
- Inspected the four official archives locally without publishing the extraction output.
- Companion CaskHub changes: 478-test full Swift suite passed before the Element addition; 14 focused tests passed afterward, including the Element regression. Strict SwiftLint passed.
- Real-app verification: Spark Mail recognized correctly; Kushview rejected as Matrix; Matrix recognized and successfully adopted into Homebrew despite remaining Kushview package receipts. Apple Motion collision is covered by a fixture; the paid app was not purchased.

- [x] Base branch is `develop` (not `master`)
- [x] Tests pass locally
- [x] Documentation reflects behavior or schema changes
- [x] CaskHub consumer impact was checked when applicable
- [x] PR title uses the semantic `<type>(scope): description` format
