### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-09-07",
-  "totalCasks": 3931,
+  "generatedDate": "2026-09-08",
+  "totalCasks": 3932,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -11619,6 +11619,12 @@
     "pritunl": {
       "primary": "securityPrivacy",
       "secondary": []
+    },
+    "privacynotes": {
+      "primary": "productivity",
+      "secondary": [
+        "securityPrivacy"
+      ]
     },
     "privadovpn": {
       "primary": "securityPrivacy",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,10 +1,10 @@
 # Daily classification update
 
-Generated 2026-09-07
+Generated 2026-09-08
 
 ## Summary
 
-- 3 new casks classified
+- 1 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
 - 0 casks renamed in Homebrew (classification migrated, no LLM call)
@@ -15,6 +15,4 @@ Generated 2026-09-07
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `minmaxcal` | menuBar | productivity | 0.90 | A menu bar calendar app that shows full-screen notifications for events. |
-| `open-science` | scienceEducation | ai | 0.75 | An AI-powered research workbench with scientific agents and notebooks, primarily for research/science use. |
-| `stockbit` | financeCrypto | - | 0.97 | Stockbit is an Indonesian stock trading and analysis platform desktop app. |
+| `privacynotes` | productivity | securityPrivacy | 0.75 | Encrypted note-taking, task, and journal app with security as a core selling point but productivity as the main function. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -38220,6 +38220,13 @@
     "og_desc": "Free and open source cross platform OpenVPN and WireGuard client."
   },
   {
+    "token": "privacynotes",
+    "homepage": "https://privacynotes.app/",
+    "title": "PrivacyNotes: Your Encrypted Vault for Notes, Tasks & Journals",
+    "meta_desc": "Note down your thoughts, tasks, and journal - encrypted, always. End-to-end encrypted with zero tracking, hosted in Switzerland.",
+    "og_desc": "Note down your thoughts, tasks, and journal - encrypted, always. End-to-end encrypted with zero tracking, hosted in Switzerland."
+  },
+  {
     "token": "privadovpn",
     "homepage": "https://privadovpn.com/",
     "title": "Best VPN & Internet Security Suite | PrivadoVPN",


### PR DESCRIPTION
# Daily classification update

Generated 2026-09-08

## Summary

- 1 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `privacynotes` | productivity | securityPrivacy | 0.75 | Encrypted note-taking, task, and journal app with security as a core selling point but productivity as the main function. |
