### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-09-09",
-  "totalCasks": 3936,
+  "generatedDate": "2026-09-10",
+  "totalCasks": 3938,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -11816,6 +11816,10 @@
       "primary": "scienceEducation",
       "secondary": []
     },
+    "psysonic": {
+      "primary": "audioMusic",
+      "secondary": []
+    },
     "ptpwebcam": {
       "primary": "videoMedia",
       "secondary": []
@@ -12240,6 +12244,10 @@
       "secondary": []
     },
     "realvnc-connect": {
+      "primary": "utilities",
+      "secondary": []
+    },
+    "realvnc-connect-viewer": {
       "primary": "utilities",
       "secondary": []
     },
@@ -16084,10 +16092,6 @@
       "primary": "utilities",
       "secondary": []
     },
-    "vnc-viewer": {
-      "primary": "utilities",
-      "secondary": []
-    },
     "vocaster-hub": {
       "primary": "other",
       "secondary": []
@@ -16701,6 +16705,12 @@
     "wrkspace": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "wsl-manager": {
+      "primary": "developerTools",
+      "secondary": [
+        "utilities"
+      ]
     },
     "wwdc": {
       "primary": "developerTools",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,27 +1,23 @@
 # Daily classification update
 
-Generated 2026-09-09
+Generated 2026-09-10
 
 ## Summary
 
-- 4 new casks classified
-- 1 classifications require manual review (confidence below 0.75)
+- 2 new casks classified
+- 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
-- 0 casks renamed in Homebrew (classification migrated, no LLM call)
+- 1 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
 - 0 casks deprecated/disabled in Homebrew (pruned)
+
+## Renamed (classification migrated)
+
+- `vnc-viewer` → `realvnc-connect-viewer`
 
 ## New classifications
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `easymac-cleaner` | utilities | securityPrivacy | 0.85 | A Mac cleaning and optimization utility that also handles privacy trace removal. |
-| `flick` | productivity | utilities | 0.70 | A gesture-based command launcher for macOS that boosts productivity through quick app/window actions. |
-| `homebrew-app` | utilities | developerTools | 0.75 | A GUI for managing Homebrew packages is a system package-management utility, closely tied to developer tooling. |
-| `zentty` | developerTools | ai | 0.85 | A native Mac terminal built for AI coding agent workflows, fitting developer tools with an AI trait. |
-
-## Manual review required
-
-| token | primary | secondary | confidence | reason |
-|---|---|---|---|---|
-| `flick` | productivity | utilities | 0.70 | A gesture-based command launcher for macOS that boosts productivity through quick app/window actions. |
+| `psysonic` | audioMusic | - | 0.95 | Desktop music streaming client for Navidrome/Subsonic servers. |
+| `wsl-manager` | developerTools | utilities | 0.85 | A VM/distro management tool for developers working with Linux/WSL environments and Docker images. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -38545,6 +38545,13 @@
     "og_desc": ""
   },
   {
+    "token": "psysonic",
+    "homepage": "https://www.psysonic.de/",
+    "title": "Psysonic - The Navidrome-First Desktop Music Client",
+    "meta_desc": "Psysonic is a modern desktop client for self-hosted music libraries. Fast, native, and beautiful - built for Navidrome and Subsonic servers.",
+    "og_desc": "Psysonic is a modern desktop client for self-hosted music libraries. Fast, native, and beautiful - built for Navidrome and Subsonic servers."
+  },
+  {
     "token": "ptpwebcam",
     "homepage": "https://ptpwebcam.org/",
     "title": "PTP Webcam",
@@ -47287,6 +47294,13 @@
     "title": "Wrkspace - Simplify Application Management",
     "meta_desc": "Wrkspace empowers developers to revolutionize installations and project launches effortlessly. With support for popular programming languages and frameworks, Wrkspace streamlines workflows and enhances productivity. Available for Mac, with Linux and Windows versions on the horizon.",
     "og_desc": "Launch projects seamlessly with Wrkspace. Accelerate your workflow and revolutionize installations effortlessly."
+  },
+  {
+    "token": "wsl-manager",
+    "homepage": "https://wslmanager.com/",
+    "title": "WSL Manager - Linux distros on Windows, native VMs on macOS",
+    "meta_desc": "Manage WSL distros on Windows and native Linux VMs on macOS. Move distros between drives, reclaim the disk space WSL keeps, turn any Docker image into a distro without Docker, manage WSL over SSH, and let AI agents drive your environment through a built-in MCP server.",
+    "og_desc": "One app for WSL distros on Windows and native Linux VMs on macOS. Move distros between drives, reclaim disk space, turn any Docker image into a distro, and let AI agents drive it all through an MCP server."
   },
   {
     "token": "wwdc",


### PR DESCRIPTION
# Daily classification update

Generated 2026-09-10

## Summary

- 2 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 1 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## Renamed (classification migrated)

- `vnc-viewer` → `realvnc-connect-viewer`

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `psysonic` | audioMusic | - | 0.95 | Desktop music streaming client for Navidrome/Subsonic servers. |
| `wsl-manager` | developerTools | utilities | 0.85 | A VM/distro management tool for developers working with Linux/WSL environments and Docker images. |
