### PR TITLE
chore: Daily cask classification update

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-09-10",
-  "totalCasks": 3938,
+  "generatedDate": "2026-09-11",
+  "totalCasks": 3942,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -2143,6 +2143,12 @@
       "primary": "videoMedia",
       "secondary": [
         "ai"
+      ]
+    },
+    "capsomnia": {
+      "primary": "utilities",
+      "secondary": [
+        "menuBar"
       ]
     },
     "captain": {
@@ -10160,6 +10166,12 @@
         "ai"
       ]
     },
+    "ollama-binary": {
+      "primary": "developerTools",
+      "secondary": [
+        "ai"
+      ]
+    },
     "ollamac": {
       "primary": "developerTools",
       "secondary": []
@@ -16651,6 +16663,19 @@
     "workbench": {
       "primary": "cloudStorage",
       "secondary": []
+    },
+    "workbuddy-ai": {
+      "primary": "productivity",
+      "secondary": [
+        "ai",
+        "officeTools"
+      ]
+    },
+    "workbuddy-cn": {
+      "primary": "productivity",
+      "secondary": [
+        "ai"
+      ]
     },
     "workflowy": {
       "primary": "productivity",

--- a/data/classification_report.md
+++ b/data/classification_report.md
@@ -1,23 +1,21 @@
 # Daily classification update
 
-Generated 2026-09-10
+Generated 2026-09-11
 
 ## Summary
 
-- 2 new casks classified
+- 4 new casks classified
 - 0 classifications require manual review (confidence below 0.75)
 - 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
-- 1 casks renamed in Homebrew (classification migrated, no LLM call)
+- 0 casks renamed in Homebrew (classification migrated, no LLM call)
 - 0 casks removed from Homebrew (pruned)
 - 0 casks deprecated/disabled in Homebrew (pruned)
-
-## Renamed (classification migrated)
-
-- `vnc-viewer` → `realvnc-connect-viewer`
 
 ## New classifications
 
 | token | primary | secondary | confidence | reason |
 |---|---|---|---|---|
-| `psysonic` | audioMusic | - | 0.95 | Desktop music streaming client for Navidrome/Subsonic servers. |
-| `wsl-manager` | developerTools | utilities | 0.85 | A VM/distro management tool for developers working with Linux/WSL environments and Docker images. |
+| `capsomnia` | utilities | menuBar | 0.85 | A system utility that keeps the Mac awake with lid closed via a menu bar/Caps Lock toggle. |
+| `ollama-binary` | developerTools | ai | 0.85 | Ollama is a local LLM runtime/tool primarily used by developers to run models, tagged with the AI trait. |
+| `workbuddy-ai` | productivity | ai, officeTools | 0.75 | An AI agent that automates office work tasks like reports and spreadsheets, fitting productivity with AI trait. |
+| `workbuddy-cn` | productivity | ai | 0.80 | AI agent tool for office productivity tasks, powered by LLM technology. |

--- a/data/homepage_metadata.json
+++ b/data/homepage_metadata.json
@@ -3684,6 +3684,13 @@
     "og_desc": "Edit YouTube and Instagram videos with CapCut's AI-powered video editor, smart templates, and creative effects. Download CapCut on desktop, mobile, or edit online."
   },
   {
+    "token": "capsomnia",
+    "homepage": "https://github.com/fuji-mak/Capsomnia/",
+    "title": "GitHub - fuji-mak/Capsomnia: A tiny macOS app that turns Caps Lock into a physical keep-awake switch for closed-lid MacBook work. · GitHub",
+    "meta_desc": "A tiny macOS app that turns Caps Lock into a physical keep-awake switch for closed-lid MacBook work. - fuji-mak/Capsomnia",
+    "og_desc": "A tiny macOS app that turns Caps Lock into a physical keep-awake switch for closed-lid MacBook work. - fuji-mak/Capsomnia"
+  },
+  {
     "token": "captain",
     "homepage": "https://getcaptain.co/",
     "title": "Captain for Mac",
@@ -35676,6 +35683,13 @@
     "og_desc": "Ollama is the easiest way to automate your work using open models, while keeping your data safe."
   },
   {
+    "token": "ollama-binary",
+    "homepage": "https://ollama.com/",
+    "title": "Ollama",
+    "meta_desc": "Ollama is the easiest way to automate your work using open models, while keeping your data safe.",
+    "og_desc": "Ollama is the easiest way to automate your work using open models, while keeping your data safe."
+  },
+  {
     "token": "ollamac",
     "homepage": "https://github.com/kevinhermawan/Ollamac",
     "title": "GitHub - kevinhermawan/Ollamac: Mac app for Ollama · GitHub",
@@ -47210,6 +47224,20 @@
     "title": "GitHub - mxcl/Workbench: Seamless, automatic, \"dotfile\" sync to iCloud. · GitHub",
     "meta_desc": "Seamless, automatic, \"dotfile\" sync to iCloud. Contribute to mxcl/Workbench development by creating an account on GitHub.",
     "og_desc": "Seamless, automatic, \"dotfile\" sync to iCloud. Contribute to mxcl/Workbench development by creating an account on GitHub."
+  },
+  {
+    "token": "workbuddy-ai",
+    "homepage": "https://www.workbuddy.ai/",
+    "title": "WorkBuddy - AI Agent for Everyday Office Work",
+    "meta_desc": "Tencent WorkBuddy is an AI Agent built for office professionals. Powered by multi-agent collaboration, it autonomously breaks down complex tasks and delivers finished, verifiable outputs - reports, decks, spreadsheets, and more.",
+    "og_desc": "Tencent WorkBuddy is an AI Agent built for office professionals. Powered by multi-agent collaboration, it autonomously breaks down complex tasks and delivers finished, verifiable outputs - reports, decks, spreadsheets, and more."
+  },
+  {
+    "token": "workbuddy-cn",
+    "homepage": "https://www.workbuddy.cn/",
+    "title": "WorkBuddy - AI Agent 办公新范式",
+    "meta_desc": "WorkBuddy 是腾讯云代码助手推出的 AI Agent 办公工具，自主规划并交付多模态复杂任务结果，支持多 Agents 并行工作，极致提效。",
+    "og_desc": "WorkBuddy 是腾讯云代码助手推出的 AI Agent 办公工具，自主规划并交付多模态复杂任务结果，支持多 Agents 并行工作，极致提效。"
   },
   {
     "token": "workflowy",


### PR DESCRIPTION
# Daily classification update

Generated 2026-09-11

## Summary

- 4 new casks classified
- 0 classifications require manual review (confidence below 0.75)
- 0 new casks **skipped** (LLM/validation failures, will retry tomorrow)
- 0 casks renamed in Homebrew (classification migrated, no LLM call)
- 0 casks removed from Homebrew (pruned)
- 0 casks deprecated/disabled in Homebrew (pruned)

## New classifications

| token | primary | secondary | confidence | reason |
|---|---|---|---|---|
| `capsomnia` | utilities | menuBar | 0.85 | A system utility that keeps the Mac awake with lid closed via a menu bar/Caps Lock toggle. |
| `ollama-binary` | developerTools | ai | 0.85 | Ollama is a local LLM runtime/tool primarily used by developers to run models, tagged with the AI trait. |
| `workbuddy-ai` | productivity | ai, officeTools | 0.75 | An AI agent that automates office work tasks like reports and spreadsheets, fitting productivity with AI trait. |
| `workbuddy-cn` | productivity | ai | 0.80 | AI agent tool for office productivity tasks, powered by LLM technology. |
