### PR TITLE
chore(release): promote independent icon manifest publishing

### DIFF
--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -1,6 +1,6 @@
 name: Extract icons
 
-# PNGs and icon_report.json share the icons branch and a single writer.
+# PNGs, icons.json, and icon_report.json share the icons branch and a single writer.
 on:
   workflow_dispatch:
     inputs:
@@ -60,9 +60,9 @@ jobs:
             python3 scripts/extract_icons.py --publish --limit "$LIMIT"
           fi
 
-      # The daily release (14:47 UTC) predates this run, and iconTokens is
-      # stamped at release time - without this, today's icons ship tomorrow.
-      - name: Cut data release with the fresh icon manifest
+      # Keep legacy iconTokens and app identities fresh for existing consumers.
+      # Independent icons.json is already published; it does not wait for this release.
+      - name: Refresh legacy category metadata
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run release.yml

--- a/docs/ICON_EXTRACTION.md
+++ b/docs/ICON_EXTRACTION.md
@@ -10,10 +10,36 @@ https://cdn.jsdelivr.net/gh/alielsokary/CaskFlow@icons/<token>.png     (primary 
 https://raw.githubusercontent.com/alielsokary/CaskFlow/icons/<token>.png   (fallback)
 ```
 
-256×256 PNG per cask token, published once (icons are not re-extracted on
-version bumps). jsDelivr caches branch refs for 12h at the edge and mirrors
+256×256 PNG per cask token. Scheduled runs skip existing icons; explicit
+`--tokens` re-extracts them. Publishing purges changed PNGs from jsDelivr;
+purge failures are reported without undoing publication. jsDelivr caches branch refs for 12h at the edge and mirrors
 served files permanently to its own storage; new icons are visible within
 minutes on first request, cached aggressively thereafter.
+
+The independent `icons.json` on the `icons` branch contains
+`{"version": 1, "hashes": {"<token>": "<Git blob SHA-1>"}}`. It is generated
+from the staged PNGs and committed alongside them on every publication, including
+selective runs. No category release is needed. Existing `iconTokens` in category
+releases stays available for older consumers; hashes are not added to categories.
+
+Manifest URL: `https://raw.githubusercontent.com/alielsokary/CaskFlow/icons/icons.json`.
+The same path is also available through jsDelivr. After a successful push, CI
+purges only changed PNG URLs and the manifest if it changed. A selective run for
+one changed icon purges that icon, not the entire collection. Unchanged images
+are not purged, and purge failures warn without undoing publication.
+
+Consumers refresh the manifest independently, compare saved hashes, and fetch
+only changed icons using the existing URLs. Verify SHA-1 of
+`blob <byte-count>\0` followed by the original PNG bytes before replacing a cached
+icon. On network errors or mismatches, retain the previous icon and retry later:
+mutable CDN content can temporarily lag behind the manifest. A CDN purge cannot
+clear a consumer's local cache. Missing or unsupported manifests should preserve
+legacy loading behavior, or the last successfully loaded manifest.
+
+CaskHub checks on startup and on foreground activation (at most once per 15
+minutes). Health > Sync now bypasses that interval and retries visible stale
+icons, even if their advertised hashes have not changed. Failed downloads also
+retry on a subsequent image load; there is no continuous background polling.
 
 ## Protocol (per cask)
 

--- a/scripts/extract_icons.py
+++ b/scripts/extract_icons.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
+from style_standards import write_json
+
 from app_identities import MANIFEST, merge_extractions, needs_refresh, record_extraction
 
 from icons_state import (  # noqa: F401  (re-exported for curate_icons/tests)
@@ -508,14 +510,57 @@ def publish_batch(pngs: dict[str, Path], report: dict[str, dict],
         _merge_report(wt, report, dirty)
         if identity_file is not None:
             merge_extractions(wt / MANIFEST, identity_file, dirty)
-        _git(wt, "add", "-A")
+        if _git(wt, "add", "-A").returncode != 0:
+            raise ExtractError("Cannot stage icons")
+        write_icon_manifest(wt)
+        if _git(wt, "add", "icons.json").returncode != 0:
+            raise ExtractError("Cannot stage icons.json")
         if _git(wt, "diff", "--cached", "--quiet").returncode == 0:
             return  # everything already on the branch
+        changed = _git(wt, "diff", "--cached", "--name-only", "--diff-filter=AM", "--", "*.png", "icons.json")
+        if changed.returncode != 0:
+            raise ExtractError("Cannot determine changed icons for CDN purge")
         _commit_and_push(wt, pngs)
+        for filename in changed.stdout.splitlines():
+            purge_file(filename)
     finally:
         if wt_added:
             _git(REPO_ROOT, "worktree", "remove", "--force", str(wt))
         shutil.rmtree(wt, ignore_errors=True)
+
+
+def write_icon_manifest(wt: Path) -> None:
+    """Describe the staged PNGs, so manifest and images publish in one commit."""
+    index = _git(wt, "ls-files", "--stage", "-z", "--", "*.png")
+    if index.returncode != 0:
+        raise ExtractError("Cannot read staged icons for icons.json")
+    hashes = {}
+    for entry in index.stdout.split("\0"):
+        if not entry:
+            continue
+        info, path = entry.split("\t", 1)
+        mode, sha, stage = info.split()
+        if stage != "0":
+            raise ExtractError("Cannot publish icons with unresolved conflicts")
+        if mode in ("100644", "100755") and "/" not in path:
+            hashes[Path(path).stem] = sha
+    write_json(wt / "icons.json", {"version": 1, "hashes": dict(sorted(hashes.items()))})
+
+
+def purge_file(filename: str) -> None:
+    """Refresh a mutable CDN file; failure must not undo a successful push."""
+    url = f"https://purge.jsdelivr.net/gh/alielsokary/CaskFlow@{ICONS_BRANCH}/{filename}"
+    try:
+        with urlopen(url, timeout=15) as response:
+            result = json.load(response)
+        paths = result.get("paths", {})
+        if result.get("status") != "finished" or not paths or any(
+            entry.get("throttled") or not entry.get("providers")
+            or not all(entry["providers"].values()) for entry in paths.values()
+        ):
+            raise ValueError(f"purge incomplete: {result}")
+    except Exception as error:
+        print(f"warning: CDN purge failed for {filename}: {error}; retry {url}")
 
 
 def _add_icons_worktree(wt: Path) -> None:

--- a/scripts/extract_icons.py
+++ b/scripts/extract_icons.py
@@ -551,7 +551,7 @@ def purge_file(filename: str) -> None:
     """Refresh a mutable CDN file; failure must not undo a successful push."""
     url = f"https://purge.jsdelivr.net/gh/alielsokary/CaskFlow@{ICONS_BRANCH}/{filename}"
     try:
-        with urlopen(url, timeout=15) as response:
+        with urlopen(url, timeout=15) as response:  # nosec B310 - fixed HTTPS scheme and jsDelivr host
             result = json.load(response)
         paths = result.get("paths", {})
         if result.get("status") != "finished" or not paths or any(

--- a/tests/test_extract_icons.py
+++ b/tests/test_extract_icons.py
@@ -387,3 +387,57 @@ def test_main_retry_parked_all_fail_stays_green(monkeypatch, tmp_path):
         "t0": {"status": "failed", "reason": "x", "attempts": 3, "updated": "2026-07-11"}})
     monkeypatch.setattr(extract_icons, "_extract_status", lambda c, o: ("failed", "boom"))
     assert extract_icons.main(["--output-dir", str(tmp_path), "--retry-parked"]) == 0
+
+
+def test_publish_manifest_and_purge_only_changed_files_after_push(monkeypatch, tmp_path):
+    import json
+    import subprocess
+
+    wt = tmp_path / "worktree"
+    wt.mkdir()
+    def git(*args):
+        return subprocess.check_output(["git", "-C", str(wt), *args], text=True).strip()
+    git("init", "-q")
+    git("config", "user.name", "Test")
+    git("config", "user.email", "test@example.com")
+    (wt / "antinote.png").write_bytes(b"old")
+    (wt / "unchanged.png").write_bytes(b"same")
+    git("add", "-A")
+    git("commit", "-qm", "initial")
+    events = []
+    monkeypatch.setattr(extract_icons.tempfile, "mkdtemp", lambda **_: str(wt))
+    monkeypatch.setattr(extract_icons, "_add_icons_worktree", lambda _: None)
+    monkeypatch.setattr(extract_icons, "_merge_report", lambda *_: None)
+    monkeypatch.setattr(extract_icons.shutil, "rmtree", lambda *a, **k: None)
+    def push(*_):
+        git("commit", "-qm", "publish")
+        manifest = json.loads(git("show", "HEAD:icons.json"))
+        assert manifest == {"version": 1, "hashes": {
+            "antinote": git("rev-parse", "HEAD:antinote.png"),
+            "unchanged": git("rev-parse", "HEAD:unchanged.png"),
+        }}
+        events.append("push")
+    monkeypatch.setattr(extract_icons, "_commit_and_push", push)
+    monkeypatch.setattr(extract_icons, "purge_file", lambda path: events.append(path))
+    png = tmp_path / "antinote.png"
+    png.write_bytes(b"new")
+    extract_icons.publish_batch({"antinote": png}, {}, set())
+    assert events == ["push", "antinote.png", "icons.json"]
+    events.clear()
+    extract_icons.publish_batch({"antinote": png}, {}, set())
+    assert events == []  # Unchanged bytes: no commit or purge.
+    png.write_bytes(b"newer")
+    def failed_push(*_):
+        raise ExtractError("push failed")
+    monkeypatch.setattr(extract_icons, "_commit_and_push", failed_push)
+    with pytest.raises(ExtractError, match="push failed"):
+        extract_icons.publish_batch({"antinote": png}, {}, set())
+    assert events == []
+
+
+def test_purge_failure_warns_without_failing_publication(monkeypatch, capsys):
+    def unavailable(*args, **kwargs):
+        raise OSError("offline")
+    monkeypatch.setattr(extract_icons, "urlopen", unavailable)
+    extract_icons.purge_file("antinote.png")
+    assert "warning: CDN purge failed for antinote" in capsys.readouterr().out

--- a/tests/test_extract_icons.py
+++ b/tests/test_extract_icons.py
@@ -395,6 +395,7 @@ def test_publish_manifest_and_purge_only_changed_files_after_push(monkeypatch, t
 
     wt = tmp_path / "worktree"
     wt.mkdir()
+
     def git(*args):
         return subprocess.check_output(["git", "-C", str(wt), *args], text=True).strip()
     git("init", "-q")
@@ -409,6 +410,7 @@ def test_publish_manifest_and_purge_only_changed_files_after_push(monkeypatch, t
     monkeypatch.setattr(extract_icons, "_add_icons_worktree", lambda _: None)
     monkeypatch.setattr(extract_icons, "_merge_report", lambda *_: None)
     monkeypatch.setattr(extract_icons.shutil, "rmtree", lambda *a, **k: None)
+
     def push(*_):
         git("commit", "-qm", "publish")
         manifest = json.loads(git("show", "HEAD:icons.json"))
@@ -418,7 +420,7 @@ def test_publish_manifest_and_purge_only_changed_files_after_push(monkeypatch, t
         }}
         events.append("push")
     monkeypatch.setattr(extract_icons, "_commit_and_push", push)
-    monkeypatch.setattr(extract_icons, "purge_file", lambda path: events.append(path))
+    monkeypatch.setattr(extract_icons, "purge_file", events.append)
     png = tmp_path / "antinote.png"
     png.write_bytes(b"new")
     extract_icons.publish_batch({"antinote": png}, {}, set())
@@ -427,6 +429,7 @@ def test_publish_manifest_and_purge_only_changed_files_after_push(monkeypatch, t
     extract_icons.publish_batch({"antinote": png}, {}, set())
     assert events == []  # Unchanged bytes: no commit or purge.
     png.write_bytes(b"newer")
+
     def failed_push(*_):
         raise ExtractError("push failed")
     monkeypatch.setattr(extract_icons, "_commit_and_push", failed_push)


### PR DESCRIPTION
## Summary

Promote the independent icon manifest and selective CDN purge implementation from develop to master. Existing image URLs and category metadata remain compatible.

After promotion, run Extract icons with a zero-cask limit to publish icons.json from the existing PNGs without overwriting the maintainer's Antinote replacement. The workflow then triggers the normal data release.

## Verification

- Develop CI passed on a111931f996157f7fceeb9301f681b4389db3032.
- Feature PR #149 passed tests and Codacy.
- 126 local Python tests passed.
- Intentional develop-to-master release promotion; no category data changes in this promotion.
